### PR TITLE
Beejones/add thin crypto layer for primitives

### DIFF
--- a/lib/crypto/DidKey.ts
+++ b/lib/crypto/DidKey.ts
@@ -278,7 +278,7 @@ export default class DidKey {
   }
 
   // Save the key or generate one if not specified by the caller
-  private setKey (key: Buffer | null): Promise<any> {
+  private setKey (key: Buffer): Promise<any> {
     switch (this._keyType) {
       case KeyType.Oct:
         return this.setOctKey(key);
@@ -291,7 +291,7 @@ export default class DidKey {
   }
 
   // Save the oct key or generate one if not specified by the caller
-  private setOctKey (key: Buffer | null): Promise<any> {
+  private setOctKey (key: Buffer): Promise<any> {
     if (!key) {
       // Generate now random buffer
       let length = this._algorithm.length ? this._algorithm.length : 16;

--- a/lib/crypto/DidKey.ts
+++ b/lib/crypto/DidKey.ts
@@ -1,0 +1,243 @@
+import { KeyType } from './KeyType';
+import { KeyUse } from './KeyUse';
+import KeyObject from './KeyObject';
+import base64url from 'base64url';
+import { Buffer } from 'buffer';
+
+/**
+ * Class to model a key
+ */
+export default class DidKey {
+  // key type
+  private _keyType: KeyType;
+
+  // key use
+  private _keyUse: KeyUse;
+
+  // algorithm to use
+  private _algorithm: any;
+
+  // the crypto object
+  private _crypto: any;
+
+  // Store symmetric key
+  private _exportable: boolean;
+
+  // Promise used to set the key
+  private _promise: PromiseLike<any>;
+
+  // Store jwk key. This is the format returned by exportKey
+  private _jwkKey: any;
+
+  // Store key object. This is the format returned by generateKey
+  private _keyObject: any;
+
+  /**
+   * Create an instance of DidKey.
+   * @param crypto The crypto object.
+   * @param algorithm Intended algorithm to use for the key.
+   * @param keyType Key type.
+   * @param keyUse Key usage.
+   * @param key The key.
+   * @param exportable True if the key is exportable.
+   */
+  public constructor (
+    crypto: any,
+    algorithm: any,
+    keyType: KeyType,
+    keyUse: KeyUse,
+    key: Buffer | null = null,
+    exportable: boolean = true
+  ) {
+    this._crypto = crypto;
+    this._algorithm = algorithm;
+    this._keyType = keyType;
+    this._keyUse = keyUse;
+    this._exportable = exportable;
+
+    this._promise = this._setKey(key);
+  }
+
+  /**
+   * Gets the key use.
+   */
+  public get keyUse (): KeyUse {
+    return this._keyUse;
+  }
+
+  /**
+   * Gets the key type.
+   */
+  public get keyType (): KeyType {
+    return this._keyType;
+  }
+
+  /**
+   * Gets the intended algorithm to use for the key.
+   */
+  public get algorithm (): any {
+    return this._algorithm;
+  }
+
+  /**
+   * Gets the exportable property of the key indicating whether the app can extract the key.
+   */
+  public get exportable (): boolean {
+    return this._exportable;
+  }
+
+  /**
+   * Gets the key in jwk format.
+   */
+  public get jwkKey (): PromiseLike<any> {
+    return this._promise.then((cryptoKey) => {
+      if (!this._keyObject) {
+        this._keyObject = new KeyObject(this.keyType, cryptoKey);
+      }
+
+      // Return the jwk key if exists
+      if (this._jwkKey) {
+        return this._jwkKey;
+      }
+
+      return this._crypto.subtle
+        .exportKey('jwk', this._isKeyPair ? this._keyObject.privateKey : this._keyObject.secretKey)
+        .then((jwkKey: any) => {
+          return (this._jwkKey = jwkKey);
+        });
+    });
+  }
+
+  /**
+   * Sign the data with the current key
+   * @param data  Data to be signed with the current key
+   */
+  public sign (data: Buffer): PromiseLike<ArrayBuffer> {
+    let key = this._isKeyPair ? this._keyObject.privateKey : this._keyObject.secretKey;
+
+    if (key) {
+      return this._crypto.subtle.sign(this._algorithm, key, data);
+    }
+
+    if (this._keyObject.isPublicKeyCrypto) {
+      throw new Error('The key has no private key for signing');
+    }
+
+    throw new Error('No secret for signing');
+  }
+
+  /**
+   * Sign the data with the current key
+   * @param data  The data signed with the current key
+   * @param signature  The signature on the data
+   */
+  public verify (data: Buffer, signature: ArrayBuffer): PromiseLike<boolean> {
+    let key = this._isKeyPair ? this._keyObject.publicKey : this._keyObject.secretKey;
+
+    if (key) {
+      return this._crypto.subtle.verify(this._algorithm, key, signature, data);
+    }
+
+    if (this._keyObject.isPublicKeyCrypto) {
+      throw new Error('The key has no public key for verifying');
+    }
+
+    throw new Error('No secret for verifying');
+  }
+
+  // True if the key is a key pair
+  private get _isKeyPair (): boolean {
+    return this._keyType === KeyType.EC || this._keyType === KeyType.RSA;
+  }
+
+  // Set keyUsage
+  private _setKeyUsage (): string[] {
+    switch (this._keyUse) {
+      case KeyUse.Encryption:
+        if (this._isKeyPair) {
+          return [ 'deriveKey', 'deriveBits' ];
+        }
+
+        return [ 'encrypt', 'decrypt' ];
+
+      case KeyUse.Signature:
+        return [ 'sign', 'verify' ];
+    }
+
+    throw new Error(`The value for KeyUse '${this._keyUse}' is invalid. Needs to be sig or enc`);
+  }
+
+  // Save the key or generate one if not specified by the caller
+  private _setKey (key: Buffer | null): PromiseLike<any> {
+    switch (this._keyType) {
+      case KeyType.Oct:
+        return this._setOctKey(key);
+
+      case KeyType.EC:
+        return this._setEcKey(key);
+    }
+
+    throw new Error(`_setKey: ${this._keyType} is not supported`);
+  }
+
+  // Save the oct key or generate one if not specified by the caller
+  private _setOctKey (key: Buffer | null): PromiseLike<any> {
+    if (!key) {
+      // Generate now random buffer
+      let length = this._algorithm.length ? this._algorithm.length : 16;
+      key = Buffer.alloc(length);
+      key = this._crypto.getRandomValues(new Uint8Array(length));
+    }
+
+    // Set the JWK key
+    let jwkKey = {};
+    if (key) {
+      jwkKey = {
+        kty: 'oct',
+        k: base64url.encode(key),
+        use: this._keyUse
+      };
+    }
+
+    this._jwkKey = jwkKey;
+    return this._crypto.subtle
+      .importKey('jwk', this._jwkKey, this._algorithm, this._exportable, this._setKeyUsage())
+      .then((keyObject: any) => {
+        this._keyObject = new KeyObject(this.keyType, keyObject);
+        return this._keyObject;
+      })
+      .catch((err: Error) => {
+        // Re-throw the error as a higher-level error.
+        throw new Error(`import error for key type '${this._keyType}' - '${err.message}'.`);
+      });
+  }
+
+  // Save the EC key or generate one if not specified by the caller
+  private _setEcKey (jwkKey: any): PromiseLike<any> {
+    if (!jwkKey) {
+      return this._crypto.subtle.generateKey(this._algorithm, this._exportable, this._setKeyUsage()).then((keyObject: any) => {
+        this._keyObject = new KeyObject(this.keyType, keyObject);
+        return this._keyObject;
+      });
+    }
+
+    this._jwkKey = jwkKey;
+    return this._crypto.subtle
+      .importKey('jwk', jwkKey, this._algorithm, this._exportable, this._setKeyUsage())
+      .then((keyObject: any) => {
+        this._keyObject = new KeyObject(this.keyType, keyObject);
+        if (this._keyObject.isPrivateKey) {
+          // import the public key too
+          // this._crypto.subtle.exportKey('jwk')
+          return this._crypto.subtle.exportKey('jwk', this._keyObject.privateKey).then((jwk: any) => {
+            return this._crypto.subtle
+              .importKey('jwk', jwk, this._algorithm, this._exportable, this._setKeyUsage())
+              .then((pubKeyObject: any) => {
+                keyObject.publicKey = pubKeyObject;
+                return (this._keyObject = new KeyObject(this.keyType, keyObject));
+              });
+          });
+        }
+      });
+  }
+}

--- a/lib/crypto/DidKeyContainer.ts
+++ b/lib/crypto/DidKeyContainer.ts
@@ -1,0 +1,30 @@
+import DidKey from './DidKey';
+
+/**
+ * Class to model a key
+ */
+export default class DidKeyContainer {
+  // list of keys
+  private _keys: DidKey[] = [];
+
+  /**
+   * Gets the array of keys.
+   */
+  public get keys (): DidKey[] {
+    return this._keys;
+  }
+
+  /**
+   * Gets the the number of keys in the container.
+   */
+  public get count (): number {
+    return this._keys.length;
+  }
+
+  /**
+   * Add a key in the container.
+   */
+  public add (key: DidKey) {
+    this._keys.push(key);
+  }
+}

--- a/lib/crypto/KeyObject.ts
+++ b/lib/crypto/KeyObject.ts
@@ -1,0 +1,117 @@
+import { KeyType } from './KeyType';
+
+/**
+ * Class to model an internal key object
+ */
+export default class KeyObject {
+  // key type
+  private _keyType: KeyType;
+
+  // The public key
+  private _publicKey: any;
+
+  // The private key
+  private _privateKey: any;
+
+  // The secret key
+  private _secretKey: any;
+
+  // The key object. Can contain a symmetric key, key pair, private or public key
+  private _keyObject: any;
+
+  // Indicates whether the object contains a key pair
+  private _isKeyPair: boolean;
+
+  /**
+   * Create an instance of DidKey.
+   * @param keyType Key type.
+   * @param keyObject The key object to store.
+   */
+  public constructor(keyType: KeyType, keyObject: any) {
+    this._keyType = keyType;
+    this._keyObject = keyObject;
+    this._isKeyPair = false;
+
+    if (!this.isPublicKeyCrypto) {
+      this._secretKey = keyObject;
+      return;
+    }
+
+    if (this._keyObject.publicKey && this._keyObject.privateKey) {
+      this._isKeyPair = true;
+      this._publicKey = this._keyObject.publicKey;
+      this._privateKey = this._keyObject.privateKey;
+      return;
+    } else {
+      if (this._keyObject.type) {
+        switch (this._keyObject.type) {
+          case 'private':
+            this._privateKey = this._keyObject;
+            return;
+          case 'public':
+            this._publicKey = this._keyObject;
+            return;
+        }
+      }
+
+      throw new Error(`Key with type '${this._keyType}' is expected to have the type public or private`);
+    }
+  }
+
+  /**
+   * Gets the key type.
+   */
+  public get keyType(): KeyType {
+    return this._keyType;
+  }
+
+  /**
+   * Gets a value indicating whether the key is a public key crypto scheme
+   */
+  public get isPublicKeyCrypto(): boolean {
+    switch (this._keyType) {
+      case KeyType.EC:
+      case KeyType.RSA:
+        return true;
+      case KeyType.Oct:
+        return false;
+    }
+
+    throw new Error(`Key type '${this._keyType}' is not supported`);
+  }
+
+  /**
+   * Gets a value indicating whether the key is a private key only
+   */
+  public get isPrivateKey(): boolean {
+    return !this.publicKey && this.privateKey;
+  }
+
+  /**
+   * Gets a value indicating whether the key object is a key pair containing a public and private key
+   */
+  public get isKeyPair(): boolean {
+    return this._isKeyPair;
+  }
+
+  /**
+   * Gets secret key
+   */
+  public get secretKey(): any {
+    return this._secretKey;
+  }
+
+  /**
+   * Gets public key
+   */
+  public get publicKey(): any {
+    return this._publicKey;
+  }
+
+  /**
+   * Gets private key
+   */
+  public get privateKey(): any {
+    return this._privateKey;
+  }
+}

--- a/lib/crypto/KeyObject.ts
+++ b/lib/crypto/KeyObject.ts
@@ -27,7 +27,7 @@ export default class KeyObject {
    * @param keyType Key type.
    * @param keyObject The key object to store.
    */
-  public constructor(keyType: KeyType, keyObject: any) {
+  public constructor (keyType: KeyType, keyObject: any) {
     this._keyType = keyType;
     this._keyObject = keyObject;
     this._isKeyPair = false;
@@ -61,14 +61,14 @@ export default class KeyObject {
   /**
    * Gets the key type.
    */
-  public get keyType(): KeyType {
+  public get keyType (): KeyType {
     return this._keyType;
   }
 
   /**
    * Gets a value indicating whether the key is a public key crypto scheme
    */
-  public get isPublicKeyCrypto(): boolean {
+  public get isPublicKeyCrypto (): boolean {
     switch (this._keyType) {
       case KeyType.EC:
       case KeyType.RSA:
@@ -83,35 +83,35 @@ export default class KeyObject {
   /**
    * Gets a value indicating whether the key is a private key only
    */
-  public get isPrivateKey(): boolean {
+  public get isPrivateKey (): boolean {
     return !this.publicKey && this.privateKey;
   }
 
   /**
    * Gets a value indicating whether the key object is a key pair containing a public and private key
    */
-  public get isKeyPair(): boolean {
+  public get isKeyPair (): boolean {
     return this._isKeyPair;
   }
 
   /**
    * Gets secret key
    */
-  public get secretKey(): any {
+  public get secretKey (): any {
     return this._secretKey;
   }
 
   /**
    * Gets public key
    */
-  public get publicKey(): any {
+  public get publicKey (): any {
     return this._publicKey;
   }
 
   /**
    * Gets private key
    */
-  public get privateKey(): any {
+  public get privateKey (): any {
     return this._privateKey;
   }
 }

--- a/lib/crypto/KeyType.ts
+++ b/lib/crypto/KeyType.ts
@@ -1,0 +1,8 @@
+/**
+ * enum to model key types
+ */
+export enum KeyType {
+  Oct = 'oct',
+  EC = 'EC',
+  RSA = 'RSA'
+}

--- a/lib/crypto/KeyUse.ts
+++ b/lib/crypto/KeyUse.ts
@@ -1,0 +1,7 @@
+/**
+ * enum to model key use
+ */
+export enum KeyUse {
+  Encryption = 'enc',
+  Signature = 'sig'
+}

--- a/lib/crypto/PairwiseKey.ts
+++ b/lib/crypto/PairwiseKey.ts
@@ -1,0 +1,121 @@
+
+const elliptic = require('elliptic');
+const BN = require('bn.js');
+import base64url from 'base64url';
+import DidKey from './DidKey';
+import { KeyType } from './KeyType';
+import { KeyUse } from './KeyUse';
+
+/**
+ * Class to model a pairwise key
+ */
+export default class PairwiseKey {
+  /**
+   * Get the index for pairwise key
+   */
+  private _id: string;
+
+  /**
+   * Get the pairwise id
+   */
+  private _peerId: string;
+
+  /**
+   * Get the pairwise key
+   */
+  private _key: DidKey | null;
+
+  /**
+   * Get the id for the pairwise key
+   */
+  public get id () {
+    return this._id;
+  }
+
+  /**
+   * Get the id for the pairwise key
+   */
+  public get key (): DidKey | null {
+    return this._key;
+  }
+
+  /**
+   * Create an instance of PairwiseKey.
+   * @param did The DID.
+   * @param peerId The peer id.
+   */
+  constructor (did: string, peerId: string) {
+    this._id = `${did}-${peerId}`;
+    this._peerId = peerId;
+    this._key = null;
+  }
+
+  /**
+   * Generate the pairwise Key.
+   * @param didMasterKey The master key for this did.
+   * @param crypto The crypto object.
+   * @param algorithm Intended algorithm to use for the key.
+   * @param keyType Key type.
+   * @param keyUse Key usage.
+   * @param exportable True if the key is exportable.
+   */
+  public generate (
+    didMasterKey: Buffer,
+    crypto: any,
+    algorithm: any,
+    keyType: KeyType,
+    keyUse: KeyUse,
+    exportable: boolean = true): PromiseLike<DidKey> {
+    switch (keyType) {
+      case KeyType.EC:
+        return this._generateEcPairwiseKey(didMasterKey, crypto, algorithm, keyType, keyUse, exportable);
+    }
+
+    throw new Error(`Pairwise key for key type ${keyType} is not supported`);
+  }
+
+  /**
+   * Generate the EC pairwise Key.
+   * @param didMasterKey The master key for this did.
+   * @param crypto The crypto object.
+   * @param algorithm Intended algorithm to use for the key.
+   * @param keyType Key type.
+   * @param keyUse Key usage.
+   * @param exportable True if the key is exportable.
+   */
+  private _generateEcPairwiseKey (
+    didMasterKey: Buffer,
+    crypto: any,
+    algorithm: any,
+    keyType: KeyType,
+    keyUse: KeyUse,
+    exportable: boolean = true): PromiseLike<DidKey> {
+      // Generate peer key
+    const alg = { name: 'hmac', hash: { name: 'SHA-256' } };
+    let hashDidKey = new DidKey(crypto, alg, KeyType.Oct, KeyUse.Signature, didMasterKey, true);
+    return hashDidKey.jwkKey.then((jwkHmacKey) => {
+      return hashDidKey.sign(Buffer.from(this._peerId))
+        .then((signature: any) => {
+          let ec = new elliptic.ec('secp256k1');
+          let privKey = new BN(Buffer.from(signature));
+          privKey = privKey.umod(ec.curve.n);
+          let pubKey = ec.g.mul(privKey);
+
+          let d = privKey.toArrayLike(Buffer, 'be', 32);
+          let x = pubKey.x.toArrayLike(Buffer, 'be', 32);
+          let y = pubKey.y.toArrayLike(Buffer, 'be', 32);
+          let jwk = {
+            crv: 'K-256',
+            d: base64url.encode(d),
+            x: base64url.encode(x),
+            y: base64url.encode(y),
+            kty: 'EC'
+          };
+
+          this._key = new DidKey(crypto, algorithm, keyType, keyUse, jwk, exportable);
+          return this._key;
+        });
+    });
+
+  }
+}

--- a/lib/crypto/PairwiseKey.ts
+++ b/lib/crypto/PairwiseKey.ts
@@ -65,10 +65,10 @@ export default class PairwiseKey {
     algorithm: any,
     keyType: KeyType,
     keyUse: KeyUse,
-    exportable: boolean = true): PromiseLike<DidKey> {
+    exportable: boolean = true): Promise<DidKey> {
     switch (keyType) {
       case KeyType.EC:
-        return this._generateEcPairwiseKey(didMasterKey, crypto, algorithm, keyType, keyUse, exportable);
+        return this.generateEcPairwiseKey(didMasterKey, crypto, algorithm, keyType, keyUse, exportable);
     }
 
     throw new Error(`Pairwise key for key type ${keyType} is not supported`);
@@ -83,13 +83,13 @@ export default class PairwiseKey {
    * @param keyUse Key usage.
    * @param exportable True if the key is exportable.
    */
-  private _generateEcPairwiseKey (
+  private generateEcPairwiseKey (
     didMasterKey: Buffer,
     crypto: any,
     algorithm: any,
     keyType: KeyType,
     keyUse: KeyUse,
-    exportable: boolean = true): PromiseLike<DidKey> {
+    exportable: boolean = true): Promise<DidKey> {
       // Generate peer key
     const alg = { name: 'hmac', hash: { name: 'SHA-256' } };
     let hashDidKey = new DidKey(crypto, alg, KeyType.Oct, KeyUse.Signature, didMasterKey, true);

--- a/lib/crypto/PairwiseKey.ts
+++ b/lib/crypto/PairwiseKey.ts
@@ -23,7 +23,7 @@ export default class PairwiseKey {
   /**
    * Get the pairwise key
    */
-  private _key: DidKey | null;
+  private _key: DidKey | undefined;
 
   /**
    * Get the id for the pairwise key
@@ -35,7 +35,7 @@ export default class PairwiseKey {
   /**
    * Get the id for the pairwise key
    */
-  public get key (): DidKey | null {
+  public get key (): DidKey | undefined {
     return this._key;
   }
 
@@ -47,7 +47,7 @@ export default class PairwiseKey {
   constructor (did: string, peerId: string) {
     this._id = `${did}-${peerId}`;
     this._peerId = peerId;
-    this._key = null;
+    this._key = undefined;
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@decentralized-identity/did-common-typescript",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -125,6 +125,11 @@
       "integrity": "sha512-ojnbBiKkZFYRfQpmtnnWTMw+rzGp/JiystjluW9jgN3VzRwilXddJ6aGQ9V/7iuDG06SBgn7ozW9k3zcAnYjYQ==",
       "dev": true
     },
+    "@types/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA=="
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -198,6 +203,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -770,14 +780,12 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -787,6 +795,22 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+    },
+    "node-webcrypto-ossl": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/node-webcrypto-ossl/-/node-webcrypto-ossl-1.0.39.tgz",
+      "integrity": "sha512-cEq67y6GJ5jcKdANi5XqejqMvM/eIGxuOOE8F+c0XS950jSpvOcjUNHLmIe3/dN/UKyUkb+dri0BU4OgmCJd2g==",
+      "requires": {
+        "mkdirp": "^0.5.1",
+        "nan": "^2.11.1",
+        "tslib": "^1.9.3",
+        "webcrypto-core": "^0.1.25"
+      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -2334,8 +2358,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
       "version": "5.11.0",
@@ -2426,6 +2449,14 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "webcrypto-core": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-0.1.26.tgz",
+      "integrity": "sha512-BZVgJZkkHyuz8loKvsaOKiBDXDpmMZf5xG4QAOlSeYdXlFUl9c1FRrVnAXcOdb4fTHMG+TRu81odJwwSfKnWTA==",
+      "requires": {
+        "tslib": "^1.7.1"
       }
     },
     "which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,11 +131,6 @@
       "integrity": "sha512-ojnbBiKkZFYRfQpmtnnWTMw+rzGp/JiystjluW9jgN3VzRwilXddJ6aGQ9V/7iuDG06SBgn7ozW9k3zcAnYjYQ==",
       "dev": true
     },
-    "@types/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA=="
-    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -215,6 +210,11 @@
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
       "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -224,6 +224,11 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -373,6 +378,20 @@
         }
       }
     },
+    "elliptic": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+      "requires": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      }
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -489,6 +508,25 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
     "homedir-polyfill": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
@@ -528,8 +566,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -770,6 +807,16 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,111 +5,117 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
-      "integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0-beta.51"
+        "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/generator": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
-      "integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.2.tgz",
+      "integrity": "sha512-f3QCuPppXxtZOEm5GWPra/uYUjmNQlu9pbAD8D/9jze4pTY83rTtB1igTBSwvkeNlC5gR24zFFkz+2WHLFQhqQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.51",
+        "@babel/types": "^7.3.2",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.10",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
-      "integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.51",
-        "@babel/template": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51"
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
-      "integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.51"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
-      "integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+      "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.51"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
-      "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
-        "js-tokens": "^3.0.0"
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        }
       }
     },
     "@babel/parser": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
-      "integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY=",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.2.tgz",
+      "integrity": "sha512-QzNUC2RO1gadg+fs21fi0Uu0OuGNzRKEmgCxoLNzbCdoprLwjfmZwzUrpUNfJPaVRwBpDY47A17yYEGWyRelnQ==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
-      "integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+      "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.51",
-        "@babel/parser": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51",
-        "lodash": "^4.17.5"
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.2.2",
+        "@babel/types": "^7.2.2"
       }
     },
     "@babel/traverse": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
-      "integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+      "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.51",
-        "@babel/generator": "7.0.0-beta.51",
-        "@babel/helper-function-name": "7.0.0-beta.51",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.51",
-        "@babel/parser": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51",
-        "debug": "^3.1.0",
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.2.2",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/parser": "^7.2.3",
+        "@babel/types": "^7.2.2",
+        "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "invariant": "^2.2.0",
-        "lodash": "^4.17.5"
+        "lodash": "^4.17.10"
       }
     },
     "@babel/types": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
-      "integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.2.tgz",
+      "integrity": "sha512-3Y6H8xlUlpbGR+XvawiH0UXehqydTmNmEpozWcXymqwcrwYAl5KMvKtQ+TF6f6E08V6Jur7v/ykdDSF+WDEIXQ==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.10",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -299,6 +305,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "dev": true
+    },
     "commander": {
       "version": "2.18.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
@@ -323,9 +335,9 @@
       }
     },
     "debug": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-      "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "requires": {
         "ms": "^2.1.1"
@@ -451,9 +463,9 @@
       }
     },
     "globals": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-      "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+      "integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
       "dev": true
     },
     "graceful-fs": {
@@ -519,15 +531,6 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -586,23 +589,23 @@
       "dev": true
     },
     "istanbul-lib-coverage": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-      "integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
       "dev": true
     },
     "istanbul-lib-instrument": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.2.tgz",
-      "integrity": "sha512-l7TD/VnBsIB2OJvSyxaLW/ab1+92dxZNH9wLH7uHPPioy3JZ8tnx2UXUdKmdkgmP2EFPzg64CToUP6dAS3U32Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
+      "integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
       "dev": true,
       "requires": {
-        "@babel/generator": "7.0.0-beta.51",
-        "@babel/parser": "7.0.0-beta.51",
-        "@babel/template": "7.0.0-beta.51",
-        "@babel/traverse": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51",
-        "istanbul-lib-coverage": "^2.0.1",
+        "@babel/generator": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/template": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "istanbul-lib-coverage": "^2.0.3",
         "semver": "^5.5.0"
       }
     },
@@ -630,6 +633,15 @@
       "requires": {
         "mkdirp": "^0.5.1",
         "xmldom": "^0.1.22"
+      }
+    },
+    "jasmine-spec-reporter": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jasmine-spec-reporter/-/jasmine-spec-reporter-4.2.1.tgz",
+      "integrity": "sha512-FZBoZu7VE5nR7Nilzy+Np8KuVIOxF4oXDPDknehCYBDE080EnlPu0afdZNmpGDBRCUBv3mj5qgqCRmk6W/K8vg==",
+      "dev": true,
+      "requires": {
+        "colors": "1.1.2"
       }
     },
     "jasmine-ts": {
@@ -686,9 +698,9 @@
       }
     },
     "jsesc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
     "lcid": {
@@ -727,15 +739,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
     },
     "lru-cache": {
       "version": "4.1.3",
@@ -846,53 +849,37 @@
       "dev": true
     },
     "nyc": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.0.1.tgz",
-      "integrity": "sha512-Op/bjhEF74IMtzMmgYt+ModTeMHoPZzHe4qseUguPBwg5qC6r4rYMBt1L3yRXQIbjUpEqmn24/1xAC/umQGU7w==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.2.0.tgz",
+      "integrity": "sha512-gQBlOqvfpYt9b2PZ7qElrHWt8x4y8ApNfbMBoDPdl3sY4/4RJwCxDGTSqhA9RnaguZjS5nW7taW8oToe86JLgQ==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
         "arrify": "^1.0.1",
-        "caching-transform": "^2.0.0",
-        "convert-source-map": "^1.5.1",
-        "debug-log": "^1.0.1",
+        "caching-transform": "^3.0.1",
+        "convert-source-map": "^1.6.0",
         "find-cache-dir": "^2.0.0",
         "find-up": "^3.0.0",
         "foreground-child": "^1.5.6",
-        "glob": "^7.1.2",
-        "istanbul-lib-coverage": "^2.0.1",
-        "istanbul-lib-hook": "^2.0.1",
-        "istanbul-lib-instrument": "^2.3.2",
-        "istanbul-lib-report": "^2.0.1",
-        "istanbul-lib-source-maps": "^2.0.1",
-        "istanbul-reports": "^2.0.0",
+        "glob": "^7.1.3",
+        "istanbul-lib-coverage": "^2.0.3",
+        "istanbul-lib-hook": "^2.0.3",
+        "istanbul-lib-instrument": "^3.0.1",
+        "istanbul-lib-report": "^2.0.4",
+        "istanbul-lib-source-maps": "^3.0.2",
+        "istanbul-reports": "^2.1.0",
         "make-dir": "^1.3.0",
         "merge-source-map": "^1.1.0",
         "resolve-from": "^4.0.0",
-        "rimraf": "^2.6.2",
+        "rimraf": "^2.6.3",
         "signal-exit": "^3.0.2",
         "spawn-wrap": "^1.4.2",
-        "test-exclude": "^5.0.0",
+        "test-exclude": "^5.1.0",
         "uuid": "^3.3.2",
-        "yargs": "11.1.0",
-        "yargs-parser": "^9.0.2"
+        "yargs": "^12.0.5",
+        "yargs-parser": "^11.1.1"
       },
       "dependencies": {
-        "align-text": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2",
-            "longest": "^1.0.1",
-            "repeat-string": "^1.5.2"
-          }
-        },
-        "amdefine": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "bundled": true,
@@ -917,9 +904,12 @@
           "dev": true
         },
         "async": {
-          "version": "1.5.2",
+          "version": "2.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.10"
+          }
         },
         "balanced-match": {
           "version": "1.0.0",
@@ -941,55 +931,41 @@
           "dev": true
         },
         "caching-transform": {
-          "version": "2.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "make-dir": "^1.0.0",
-            "md5-hex": "^2.0.0",
-            "package-hash": "^2.0.0",
-            "write-file-atomic": "^2.0.0"
+            "hasha": "^3.0.0",
+            "make-dir": "^1.3.0",
+            "package-hash": "^3.0.0",
+            "write-file-atomic": "^2.3.0"
           }
         },
         "camelcase": {
-          "version": "1.2.1",
+          "version": "5.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "center-align": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "^0.1.3",
-            "lazy-cache": "^1.0.3"
-          }
+          "dev": true
         },
         "cliui": {
-          "version": "2.1.0",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
-            "wordwrap": "0.0.2"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
           "dev": true
+        },
+        "commander": {
+          "version": "2.17.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "commondir": {
           "version": "1.0.1",
@@ -1002,9 +978,12 @@
           "dev": true
         },
         "convert-source-map": {
-          "version": "1.5.1",
+          "version": "1.6.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
         },
         "cross-spawn": {
           "version": "4.0.2",
@@ -1016,17 +995,12 @@
           }
         },
         "debug": {
-          "version": "3.1.0",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
-        },
-        "debug-log": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
@@ -1039,6 +1013,14 @@
           "dev": true,
           "requires": {
             "strip-bom": "^3.0.0"
+          }
+        },
+        "end-of-stream": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.4.0"
           }
         },
         "error-ex": {
@@ -1055,12 +1037,12 @@
           "dev": true
         },
         "execa": {
-          "version": "0.7.0",
+          "version": "1.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
             "is-stream": "^1.1.0",
             "npm-run-path": "^2.0.0",
             "p-finally": "^1.0.0",
@@ -1069,11 +1051,13 @@
           },
           "dependencies": {
             "cross-spawn": {
-              "version": "5.1.0",
+              "version": "6.0.5",
               "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "^4.0.1",
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
                 "shebang-command": "^1.2.0",
                 "which": "^1.2.9"
               }
@@ -1118,12 +1102,15 @@
           "dev": true
         },
         "get-stream": {
-          "version": "3.0.0",
+          "version": "4.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -1136,28 +1123,25 @@
           }
         },
         "graceful-fs": {
-          "version": "4.1.11",
+          "version": "4.1.15",
           "bundled": true,
           "dev": true
         },
         "handlebars": {
-          "version": "4.0.11",
+          "version": "4.0.12",
           "bundled": true,
           "dev": true,
           "requires": {
-            "async": "^1.4.0",
+            "async": "^2.5.0",
             "optimist": "^0.6.1",
-            "source-map": "^0.4.4",
-            "uglify-js": "^2.6"
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
           },
           "dependencies": {
             "source-map": {
-              "version": "0.4.4",
+              "version": "0.6.1",
               "bundled": true,
-              "dev": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
+              "dev": true
             }
           }
         },
@@ -1165,6 +1149,14 @@
           "version": "3.0.0",
           "bundled": true,
           "dev": true
+        },
+        "hasha": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-stream": "^1.0.1"
+          }
         },
         "hosted-git-info": {
           "version": "2.7.1",
@@ -1191,17 +1183,12 @@
           "dev": true
         },
         "invert-kv": {
-          "version": "1.0.0",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-buffer": {
-          "version": "1.1.6",
           "bundled": true,
           "dev": true
         },
@@ -1229,12 +1216,12 @@
           "dev": true
         },
         "istanbul-lib-coverage": {
-          "version": "2.0.1",
+          "version": "2.0.3",
           "bundled": true,
           "dev": true
         },
         "istanbul-lib-hook": {
-          "version": "2.0.1",
+          "version": "2.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -1242,22 +1229,32 @@
           }
         },
         "istanbul-lib-report": {
-          "version": "2.0.1",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "istanbul-lib-coverage": "^2.0.1",
+            "istanbul-lib-coverage": "^2.0.3",
             "make-dir": "^1.3.0",
-            "supports-color": "^5.4.0"
+            "supports-color": "^6.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "6.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "istanbul-lib-source-maps": {
-          "version": "2.0.1",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "^3.1.0",
-            "istanbul-lib-coverage": "^2.0.1",
+            "debug": "^4.1.1",
+            "istanbul-lib-coverage": "^2.0.3",
             "make-dir": "^1.3.0",
             "rimraf": "^2.6.2",
             "source-map": "^0.6.1"
@@ -1271,7 +1268,7 @@
           }
         },
         "istanbul-reports": {
-          "version": "2.0.0",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -1283,26 +1280,12 @@
           "bundled": true,
           "dev": true
         },
-        "kind-of": {
-          "version": "3.2.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
         "lcid": {
-          "version": "1.0.0",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "invert-kv": "^1.0.0"
+            "invert-kv": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -1325,18 +1308,18 @@
             "path-exists": "^3.0.0"
           }
         },
+        "lodash": {
+          "version": "4.17.11",
+          "bundled": true,
+          "dev": true
+        },
         "lodash.flattendeep": {
           "version": "4.4.0",
           "bundled": true,
           "dev": true
         },
-        "longest": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "lru-cache": {
-          "version": "4.1.3",
+          "version": "4.1.5",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -1352,25 +1335,22 @@
             "pify": "^3.0.0"
           }
         },
-        "md5-hex": {
-          "version": "2.0.0",
+        "map-age-cleaner": {
+          "version": "0.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-o-matic": "^0.1.1"
+            "p-defer": "^1.0.0"
           }
         },
-        "md5-o-matic": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
         "mem": {
-          "version": "1.1.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "mimic-fn": "^1.0.0"
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^1.0.0",
+            "p-is-promise": "^1.1.0"
           }
         },
         "merge-source-map": {
@@ -1422,7 +1402,12 @@
           }
         },
         "ms": {
-          "version": "2.0.0",
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "nice-try": {
+          "version": "1.0.5",
           "bundled": true,
           "dev": true
         },
@@ -1473,22 +1458,32 @@
           "dev": true
         },
         "os-locale": {
-          "version": "2.1.0",
+          "version": "3.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
           }
+        },
+        "p-defer": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
         },
         "p-finally": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
+        "p-is-promise": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
         "p-limit": {
-          "version": "2.0.0",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -1509,13 +1504,13 @@
           "dev": true
         },
         "package-hash": {
-          "version": "2.0.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
+            "graceful-fs": "^4.1.15",
+            "hasha": "^3.0.0",
             "lodash.flattendeep": "^4.4.0",
-            "md5-hex": "^2.0.0",
             "release-zalgo": "^1.0.0"
           }
         },
@@ -1569,6 +1564,15 @@
           "bundled": true,
           "dev": true
         },
+        "pump": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
         "read-pkg": {
           "version": "3.0.0",
           "bundled": true,
@@ -1596,11 +1600,6 @@
             "es6-error": "^4.0.1"
           }
         },
-        "repeat-string": {
-          "version": "1.6.1",
-          "bundled": true,
-          "dev": true
-        },
         "require-directory": {
           "version": "2.1.1",
           "bundled": true,
@@ -1616,25 +1615,21 @@
           "bundled": true,
           "dev": true
         },
-        "right-align": {
-          "version": "0.1.3",
+        "rimraf": {
+          "version": "2.6.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "align-text": "^0.1.1"
+            "glob": "^7.1.3"
           }
         },
-        "rimraf": {
-          "version": "2.6.2",
+        "safe-buffer": {
+          "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
+          "dev": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.6.0",
           "bundled": true,
           "dev": true
         },
@@ -1661,12 +1656,6 @@
           "bundled": true,
           "dev": true
         },
-        "source-map": {
-          "version": "0.5.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
         "spawn-wrap": {
           "version": "1.4.2",
           "bundled": true,
@@ -1681,7 +1670,7 @@
           }
         },
         "spdx-correct": {
-          "version": "3.0.0",
+          "version": "3.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -1690,7 +1679,7 @@
           }
         },
         "spdx-exceptions": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "bundled": true,
           "dev": true
         },
@@ -1704,7 +1693,7 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.0",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true
         },
@@ -1735,16 +1724,8 @@
           "bundled": true,
           "dev": true
         },
-        "supports-color": {
-          "version": "5.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
         "test-exclude": {
-          "version": "5.0.0",
+          "version": "5.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -1755,35 +1736,22 @@
           }
         },
         "uglify-js": {
-          "version": "2.8.29",
+          "version": "3.4.9",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
+            "commander": "~2.17.1",
+            "source-map": "~0.6.1"
           },
           "dependencies": {
-            "yargs": {
-              "version": "3.10.0",
+            "source-map": {
+              "version": "0.6.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
-              "requires": {
-                "camelcase": "^1.0.2",
-                "cliui": "^2.1.0",
-                "decamelize": "^1.0.0",
-                "window-size": "0.1.0"
-              }
+              "optional": true
             }
           }
-        },
-        "uglify-to-browserify": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "uuid": {
           "version": "3.3.2",
@@ -1791,7 +1759,7 @@
           "dev": true
         },
         "validate-npm-package-license": {
-          "version": "3.0.3",
+          "version": "3.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -1811,12 +1779,6 @@
           "version": "2.0.0",
           "bundled": true,
           "dev": true
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
@@ -1871,7 +1833,7 @@
           "dev": true
         },
         "write-file-atomic": {
-          "version": "2.3.0",
+          "version": "2.4.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -1881,7 +1843,7 @@
           }
         },
         "y18n": {
-          "version": "3.2.1",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
@@ -1891,87 +1853,31 @@
           "dev": true
         },
         "yargs": {
-          "version": "11.1.0",
+          "version": "12.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
             "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
             "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
+            "os-locale": "^3.0.0",
             "require-directory": "^2.1.1",
             "require-main-filename": "^1.0.1",
             "set-blocking": "^2.0.0",
             "string-width": "^2.0.0",
             "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
-          },
-          "dependencies": {
-            "cliui": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
-              }
-            },
-            "find-up": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "locate-path": "^2.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
-              }
-            },
-            "p-limit": {
-              "version": "1.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-try": "^1.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-limit": "^1.1.0"
-              }
-            },
-            "p-try": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            }
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
           }
         },
         "yargs-parser": {
-          "version": "9.0.2",
+          "version": "11.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
-            }
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -48,5 +48,10 @@
   },
   "files": [
     "dist/lib/**/*"
-  ]
+  ],
+  "dependencies": {
+    "@types/q": "^1.5.1",
+    "base64url": "^3.0.1",
+    "node-webcrypto-ossl": "^1.0.39"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "jasmine": "^3.2.0",
     "jasmine-reporters": "^2.3.2",
     "jasmine-ts": "^0.2.1",
-    "nyc": "^13.0.1",
+    "jasmine-spec-reporter": "^4.2.1",
+    "nyc": "^13.1.0",
     "source-map-support": "^0.5.9",
     "tslint": "^5.11.0",
     "tslint-config-standard": "^8.0.1",
@@ -50,7 +51,6 @@
     "dist/lib/**/*"
   ],
   "dependencies": {
-    "@types/q": "^1.5.1",
     "base64url": "^3.0.1",
     "node-webcrypto-ossl": "^1.0.39"
   }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   ],
   "dependencies": {
     "base64url": "^3.0.1",
+    "elliptic": "^6.4.1",
     "node-webcrypto-ossl": "^1.0.39"
   }
 }

--- a/tests/crypto/DidKey.spec.ts
+++ b/tests/crypto/DidKey.spec.ts
@@ -1,0 +1,207 @@
+import DidKey from '../../lib/crypto/DidKey';
+import { KeyType } from '../../lib/crypto/KeyType';
+import { KeyUse } from '../../lib/crypto/KeyUse';
+import KeyObject from '../../lib/crypto/KeyObject';
+import WebCrypto from 'node-webcrypto-ossl';
+import base64url from 'base64url';
+
+class CryptoObject {
+  /** Name of the crypto object */
+  public name: string = '';
+
+  /** Crypto object  */
+  public crypto: any = null;
+}
+
+const webCryptoClass = new WebCrypto();
+
+const crytoObjects: CryptoObject[] = [ { name: 'node-webcrypto-ossl', crypto: webCryptoClass } ];
+
+describe('DidKey', () => {
+  describe('Test constructor oct key', () => {
+    it('Should set the right properties including symmetric key.', (done) => {
+      let sampleKey = '1234567890123456';
+      crytoObjects.forEach((cryptoObj) => {
+        console.log(`Crypto object: ${cryptoObj.name}`);
+        const alg = { name: 'hmac', hash: 'SHA-256' };
+        let didKey = new DidKey(cryptoObj.crypto, alg, KeyType.Oct, KeyUse.Signature, Buffer.from(sampleKey), true);
+        expect(KeyType.Oct).toEqual(didKey.keyType);
+        expect(KeyUse.Signature).toEqual(didKey.keyUse);
+        expect(alg).toEqual(didKey.algorithm);
+        expect(true).toEqual(didKey.exportable);
+
+        didKey.jwkKey.then((key) => {
+          expect(key).not.toBeNull();
+          expect(key.kty).toBe('oct');
+          expect(base64url.encode(Buffer.from(sampleKey))).toBe(key.k);
+          done();
+        });
+      });
+    });
+
+    it('generate symmetric key.', (done) => {
+      crytoObjects.forEach((cryptoObj) => {
+        console.log(`Crypto object: ${cryptoObj.name}`);
+        const alg = { name: 'hmac', hash: 'SHA-256' };
+        let didKey = new DidKey(cryptoObj.crypto, alg, KeyType.Oct, KeyUse.Signature, null, true);
+        expect(KeyType.Oct).toEqual(didKey.keyType);
+        expect(KeyUse.Signature).toEqual(didKey.keyUse);
+        expect(alg).toEqual(didKey.algorithm);
+        expect(true).toEqual(didKey.exportable);
+
+        didKey.jwkKey.then((key) => {
+          expect(key).not.toBeNull();
+          expect(key.kty).toBe('oct');
+          expect(key.k).not.toBeNull();
+          expect(key.k).not.toBeUndefined();
+          done();
+        });
+      });
+    });
+
+    /*
+     it('Check throws.', (done) => {
+      // expect(new DidKey(webCryptoClass, { name: 'xxx' }, KeyType.Oct, KeyUse.Encryption, null, true)).toThrowError();
+      let didKey = new DidKey(webCryptoClass, { name: 'xxx' }, KeyType.Oct, KeyUse.Encryption, null, true);
+      expect(() => didKey.jwkKey.then()).toThrowError();
+
+      done();
+     });
+     */
+  });
+
+  describe('Test signing with oct key', () => {
+    it('HMAC-SHA256.', (done) => {
+      let sampleKey = '1234567890';
+      crytoObjects.forEach((cryptoObj) => {
+        console.log(`Crypto object: ${cryptoObj.name}`);
+        const alg = { name: 'hmac', hash: { name: 'SHA-256' } };
+        let didKey = new DidKey(cryptoObj.crypto, alg, KeyType.Oct, KeyUse.Signature, Buffer.from(sampleKey), true);
+
+        const data = 'abcdefghij';
+
+        // Make sure the key is set (promise is completed)
+        didKey.jwkKey.then(() => {
+          didKey.sign(Buffer.from(data)).then((signature: ArrayBuffer) => {
+            didKey.verify(Buffer.from(data), signature).then((correct: boolean) => {
+              expect(true).toBe(correct);
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    it('HMAC-SHA512.', (done) => {
+      let sampleKey = '1234567890';
+      crytoObjects.forEach((cryptoObj) => {
+        console.log(`Crypto object: ${cryptoObj.name}`);
+        const alg = { name: 'hmac', hash: { name: 'SHA-512' } };
+        let didKey = new DidKey(cryptoObj.crypto, alg, KeyType.Oct, KeyUse.Signature, Buffer.from(sampleKey), true);
+
+        const data = 'abcdefghij';
+        didKey.jwkKey.then(() => {
+          didKey.sign(Buffer.from(data)).then((signature: ArrayBuffer) => {
+            didKey.verify(Buffer.from(data), signature).then((correct: boolean) => {
+              expect(true).toBe(correct);
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('ECDSA', () => {
+    it('secp256k1 sign and verify.', (done) => {
+      crytoObjects.forEach((cryptoObj) => {
+        console.log(`Crypto object: ${cryptoObj.name}`);
+        const alg = { name: 'ECDSA', namedCurve: 'K-256', hash: { name: 'SHA-256' } };
+        let didKey = new DidKey(cryptoObj.crypto, alg, KeyType.EC, KeyUse.Signature, null, true);
+
+        const data = 'abcdefghij';
+        didKey.jwkKey.then(() => {
+          didKey.sign(Buffer.from(data)).then((signature: ArrayBuffer) => {
+            didKey.verify(Buffer.from(data), signature).then((correct: boolean) => {
+              expect(true).toBe(correct);
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    describe('ECDSA', () => {
+      it('secp256k1 sign and verify with imported key.', (done) => {
+        crytoObjects.forEach((cryptoObj) => {
+          console.log(`Crypto object: ${cryptoObj.name}`);
+          const alg = { name: 'ECDSA', namedCurve: 'K-256', hash: { name: 'SHA-256' } };
+          let generatedDidKey = new DidKey(cryptoObj.crypto, alg, KeyType.EC, KeyUse.Signature, null, true);
+          generatedDidKey.jwkKey.then((jwk) => {
+            let didKey = new DidKey(cryptoObj.crypto, alg, KeyType.EC, KeyUse.Signature, jwk, true);
+
+            const data = 'abcdefghij';
+            didKey.jwkKey.then(() => {
+              didKey.sign(Buffer.from(data)).then((signature: ArrayBuffer) => {
+                // Make sure there is only the public key
+                jwk.d = undefined;
+                didKey = new DidKey(cryptoObj.crypto, alg, KeyType.EC, KeyUse.Signature, jwk, true);
+                didKey.jwkKey.then(() => {
+                  didKey.verify(Buffer.from(data), signature).then((correct: boolean) => {
+                    expect(true).toBe(correct);
+                    done();
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('secp256k1 import.', (done) => {
+      crytoObjects.forEach((cryptoObj) => {
+        console.log(`Crypto object: ${cryptoObj.name}`);
+        const alg = { name: 'ECDSA', namedCurve: 'K-256', hash: { name: 'SHA-256' } };
+
+        // Generate the key pair
+        let didKey = new DidKey(cryptoObj.crypto, alg, KeyType.EC, KeyUse.Signature, null, true);
+
+        didKey.jwkKey.then((ecKey1) => {
+          expect(ecKey1).not.toBeNull();
+          expect('K-256').toBe(ecKey1.crv);
+          expect('EC').toBe(ecKey1.kty);
+          done();
+        });
+      });
+    });
+
+    it('secp256k1 encrypt and decrypt.', (done) => {
+      crytoObjects.forEach((cryptoObj) => {
+        console.log(`Crypto object: ${cryptoObj.name}`);
+
+        console.log('Generate my key');
+        let alg: any = { name: 'ECDH', namedCurve: 'K-256' };
+        let myDidKey = new DidKey(cryptoObj.crypto, alg, KeyType.EC, KeyUse.Encryption, null, true);
+
+        myDidKey.jwkKey.then((myJwkEcKey) => {
+          cryptoObj.crypto.subtle
+            .importKey('jwk', myJwkEcKey, alg, true, [ 'deriveKey', 'deriveBits' ])
+            .then((ecKey: any) => {
+              let privateEcKey = new KeyObject(KeyType.EC, ecKey);
+              myJwkEcKey.d = undefined;
+              cryptoObj.crypto.subtle
+                .importKey('jwk', myJwkEcKey, alg, true, [ 'deriveKey', 'deriveBits' ])
+                .then((ecKey: any) => {
+                  alg.public = ecKey;
+                  cryptoObj.crypto.subtle.deriveBits(alg, privateEcKey.privateKey, 128).then((bits: any) => {
+                    expect(16).toBe(bits.byteLength);
+                    done();
+                  });
+                });
+            });
+        });
+      });
+    });
+  });
+});

--- a/tests/crypto/DidKey.spec.ts
+++ b/tests/crypto/DidKey.spec.ts
@@ -35,6 +35,9 @@ describe('DidKey', () => {
           expect(key.kty).toBe('oct');
           expect(base64url.encode(Buffer.from(sampleKey))).toBe(key.k);
           done();
+        })
+        .catch((err) => {
+          fail(`Error occured: '${err}'`);
         });
       });
     });
@@ -55,19 +58,25 @@ describe('DidKey', () => {
           expect(key.k).not.toBeNull();
           expect(key.k).not.toBeUndefined();
           done();
+        })
+        .catch((err) => {
+          fail(`Error occured: '${err}'`);
         });
       });
     });
 
-    /*
-     it('Check throws.', (done) => {
-      // expect(new DidKey(webCryptoClass, { name: 'xxx' }, KeyType.Oct, KeyUse.Encryption, null, true)).toThrowError();
+    it('Check throws.', (done) => {
       let didKey = new DidKey(webCryptoClass, { name: 'xxx' }, KeyType.Oct, KeyUse.Encryption, null, true);
-      expect(() => didKey.jwkKey.then()).toThrowError();
+      didKey.jwkKey.then(() => {
+        fail('should throw exception');
+      })
+      .catch((err) => {
+        expect(err).toBeDefined();
+      });
 
       done();
-     });
-     */
+    });
+
   });
 
   describe('Test signing with oct key', () => {
@@ -86,8 +95,17 @@ describe('DidKey', () => {
             didKey.verify(Buffer.from(data), signature).then((correct: boolean) => {
               expect(true).toBe(correct);
               done();
+            })
+            .catch((err) => {
+              fail(`Error occured: '${err}'`);
             });
+          })
+          .catch((err) => {
+            fail(`Error occured: '${err}'`);
           });
+        })
+        .catch((err) => {
+          fail(`Error occured: '${err}'`);
         });
       });
     });
@@ -105,8 +123,17 @@ describe('DidKey', () => {
             didKey.verify(Buffer.from(data), signature).then((correct: boolean) => {
               expect(true).toBe(correct);
               done();
+            })
+            .catch((err) => {
+              fail(`Error occured: '${err}'`);
             });
+          })
+          .catch((err) => {
+            fail(`Error occured: '${err}'`);
           });
+        })
+        .catch((err) => {
+          fail(`Error occured: '${err}'`);
         });
       });
     });
@@ -116,7 +143,7 @@ describe('DidKey', () => {
     it('secp256k1 sign and verify.', (done) => {
       crytoObjects.forEach((cryptoObj) => {
         console.log(`Crypto object: ${cryptoObj.name}`);
-        const alg = { name: 'ECDSA', namedCurve: 'K-256', hash: { name: 'SHA-256' } };
+        const alg = { name: 'ECDSA', namedCurve: 'P-256K', hash: { name: 'SHA-256' } };
         let didKey = new DidKey(cryptoObj.crypto, alg, KeyType.EC, KeyUse.Signature, null, true);
 
         const data = 'abcdefghij';
@@ -125,8 +152,17 @@ describe('DidKey', () => {
             didKey.verify(Buffer.from(data), signature).then((correct: boolean) => {
               expect(true).toBe(correct);
               done();
+            })
+            .catch((err) => {
+              fail(`Error occured: '${err}'`);
             });
+          })
+          .catch((err) => {
+            fail(`Error occured: '${err}'`);
           });
+        })
+        .catch((err) => {
+          fail(`Error occured: '${err}'`);
         });
       });
     });
@@ -135,7 +171,7 @@ describe('DidKey', () => {
       it('secp256k1 sign and verify with imported key.', (done) => {
         crytoObjects.forEach((cryptoObj) => {
           console.log(`Crypto object: ${cryptoObj.name}`);
-          const alg = { name: 'ECDSA', namedCurve: 'K-256', hash: { name: 'SHA-256' } };
+          const alg = { name: 'ECDSA', namedCurve: 'P-256K', hash: { name: 'SHA-256' } };
           let generatedDidKey = new DidKey(cryptoObj.crypto, alg, KeyType.EC, KeyUse.Signature, null, true);
           generatedDidKey.jwkKey.then((jwk) => {
             let didKey = new DidKey(cryptoObj.crypto, alg, KeyType.EC, KeyUse.Signature, jwk, true);
@@ -150,10 +186,25 @@ describe('DidKey', () => {
                   didKey.verify(Buffer.from(data), signature).then((correct: boolean) => {
                     expect(true).toBe(correct);
                     done();
+                  })
+                  .catch((err) => {
+                    fail(`Error occured: '${err}'`);
                   });
+                })
+                .catch((err) => {
+                  fail(`Error occured: '${err}'`);
                 });
+              })
+              .catch((err) => {
+                fail(`Error occured: '${err}'`);
               });
+            })
+            .catch((err) => {
+              fail(`Error occured: '${err}'`);
             });
+          })
+          .catch((err) => {
+            fail(`Error occured: '${err}'`);
           });
         });
       });
@@ -162,7 +213,7 @@ describe('DidKey', () => {
     it('secp256k1 import.', (done) => {
       crytoObjects.forEach((cryptoObj) => {
         console.log(`Crypto object: ${cryptoObj.name}`);
-        const alg = { name: 'ECDSA', namedCurve: 'K-256', hash: { name: 'SHA-256' } };
+        const alg = { name: 'ECDSA', namedCurve: 'P-256K', hash: { name: 'SHA-256' } };
 
         // Generate the key pair
         let didKey = new DidKey(cryptoObj.crypto, alg, KeyType.EC, KeyUse.Signature, null, true);
@@ -172,6 +223,9 @@ describe('DidKey', () => {
           expect('K-256').toBe(ecKey1.crv);
           expect('EC').toBe(ecKey1.kty);
           done();
+        })
+        .catch((err) => {
+          fail(`Error occured: '${err}'`);
         });
       });
     });
@@ -181,7 +235,7 @@ describe('DidKey', () => {
         console.log(`Crypto object: ${cryptoObj.name}`);
 
         console.log('Generate my key');
-        let alg: any = { name: 'ECDH', namedCurve: 'K-256' };
+        let alg: any = { name: 'ECDH', namedCurve: 'P-256K' };
         let myDidKey = new DidKey(cryptoObj.crypto, alg, KeyType.EC, KeyUse.Encryption, null, true);
 
         myDidKey.jwkKey.then((myJwkEcKey) => {
@@ -197,54 +251,24 @@ describe('DidKey', () => {
                   cryptoObj.crypto.subtle.deriveBits(alg, privateEcKey.privateKey, 128).then((bits: any) => {
                     expect(16).toBe(bits.byteLength);
                     done();
+                  })
+                  .catch((err: any) => {
+                    fail(`Error occured: '${err}'`);
                   });
+                })
+                .catch((err: any) => {
+                  fail(`Error occured: '${err}'`);
                 });
+            })
+            .catch((err: any) => {
+              fail(`Error occured: '${err}'`);
             });
+        })
+        .catch((err: any) => {
+          fail(`Error occured: '${err}'`);
         });
       });
     });
 
-/*
-      it('Check PairwiseId generation uniqueness', () => {
-        let inx: number = 0;
-        let results: string[] = [];
-        for (inx=0 ; inx < 1000; inx++){
-          let address: string = `m/${inx}/0`;
-          let pwId: string = pairwiseId.generate(address, 'http://domain.com', 'did:sidetree:ignored');
-          results.push(pwId);
-          expect(1).toBe(results.filter(element => element === pwId).length);
-        }
-    });
-
-    it('Check PairwiseId generation uniqueness with different seed', () => {
-      let seed = Buffer.from('yprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi');
-      let pairwiseId = new PairwiseId(seed);
-
-      let inx: number = 0;
-      for (inx=0 ; inx < 1000; inx++){
-        let address: string = `m/0/${inx}`;
-        let pwId: string = pairwiseId.generate(address, 'http://domain.com', 'did:sidetree:ignored');
-        expect(0).toBe(pairwiseIds.filter(element => element === pwId).length);
-      }
-  });
-
-  it('Check PairwiseId generation uniqueness with different peer', () => {
-    let inx: number = 0;
-    for (inx=0 ; inx < 1000; inx++){
-      let address: string = `m/0/${inx}`;
-      let pwId: string = pairwiseId.generate(address, 'http://domain1.com', 'did:sidetree:ignored');
-      expect(0).toBe(pairwiseIds.filter(element => element === pwId).length);
-    }
-  });
-
-  it('Check PairwiseId generation uniqueness with different did', () => {
-    let inx: number = 0;
-    for (inx=0 ; inx < 1000; inx++){
-      let address: string = `m/0/${inx}`;
-      let pwId: string = pairwiseId.generate(address, 'http://domain.com', 'did:sidetree:ignored1');
-      expect(0).toBe(pairwiseIds.filter(element => element === pwId).length);
-    }
-  });
-*/
   });
 });

--- a/tests/crypto/DidKey.spec.ts
+++ b/tests/crypto/DidKey.spec.ts
@@ -203,5 +203,48 @@ describe('DidKey', () => {
         });
       });
     });
+
+/*
+      it('Check PairwiseId generation uniqueness', () => {
+        let inx: number = 0;
+        let results: string[] = [];
+        for (inx=0 ; inx < 1000; inx++){
+          let address: string = `m/${inx}/0`;
+          let pwId: string = pairwiseId.generate(address, 'http://domain.com', 'did:sidetree:ignored');
+          results.push(pwId);
+          expect(1).toBe(results.filter(element => element === pwId).length);
+        }
+    });
+
+    it('Check PairwiseId generation uniqueness with different seed', () => {
+      let seed = Buffer.from('yprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi');
+      let pairwiseId = new PairwiseId(seed);
+
+      let inx: number = 0;
+      for (inx=0 ; inx < 1000; inx++){
+        let address: string = `m/0/${inx}`;
+        let pwId: string = pairwiseId.generate(address, 'http://domain.com', 'did:sidetree:ignored');
+        expect(0).toBe(pairwiseIds.filter(element => element === pwId).length);
+      }
+  });
+
+  it('Check PairwiseId generation uniqueness with different peer', () => {
+    let inx: number = 0;
+    for (inx=0 ; inx < 1000; inx++){
+      let address: string = `m/0/${inx}`;
+      let pwId: string = pairwiseId.generate(address, 'http://domain1.com', 'did:sidetree:ignored');
+      expect(0).toBe(pairwiseIds.filter(element => element === pwId).length);
+    }
+  });
+
+  it('Check PairwiseId generation uniqueness with different did', () => {
+    let inx: number = 0;
+    for (inx=0 ; inx < 1000; inx++){
+      let address: string = `m/0/${inx}`;
+      let pwId: string = pairwiseId.generate(address, 'http://domain.com', 'did:sidetree:ignored1');
+      expect(0).toBe(pairwiseIds.filter(element => element === pwId).length);
+    }
+  });
+*/
   });
 });

--- a/tests/crypto/DidKeyPairwise.spec.ts
+++ b/tests/crypto/DidKeyPairwise.spec.ts
@@ -8,23 +8,6 @@ const crypto = new WebCrypto();
 describe('DidKey Pairwise keys', () => {
 
   describe('Test Pairwise key generation', () => {
-
-    it('Check PairwiseId generation uniqueness', () => {
-      let inx: number = 0;
-      let results: string[] = [];
-      const alg = { name: 'ECDSA', namedCurve: 'K-256', hash: { name: 'SHA-256' } };
-      let didKey: DidKey = new DidKey(crypto, alg, KeyType.EC, KeyUse.Signature, null);
-      for (inx = 0 ; inx < 1000; inx++) {
-        didKey.generatePairwise(seed, `did=${inx}`, 'peer').then((pairwiseKey: DidKey) => {
-          pairwiseKey.jwkKey.then((jwk) => {
-            results.push(jwk.d);
-            console.log(`Check ${jwk.d} ${results.length}`);
-            expect(1).toBe(results.filter(element => element === jwk.d).length);
-          });
-        });
-      }
-    });
-
     let seed = Buffer.from('xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi');
 
     let pairwiseKeys: {pwid: string, inx: number, key: string}[] = [
@@ -36,8 +19,8 @@ describe('DidKey Pairwise keys', () => {
       { pwid: 'peerid-6', inx: 5, key: 'PMhhBrw9LAsYS34DCDFnxeG5eI0noOW8dJbhNW8jZR4' },
       { pwid: 'peerid-7', inx: 6, key: 'aoKDyrnQEwWLTvUlEgnvsaVm-yW8LfvaFRP51Rpo1d8' },
       { pwid: 'peerid-8', inx: 7, key: 'sPGK4xCGBmhjTGVSxzgTNTEr54gHtbTzWRhAHE0YQGY' },
-      { pwid: 'peerid-10', inx: 8, key: 'qKRsC7UkrM82gXZCW4oAeZnJJj7ASFJQkgrK8ppGzxc' },
-      { pwid: 'peerid-9', inx: 9, key: 'jWHSkVVAx5ASBGevjB6Y8WK1WCtvMyK8ThUdynPXtQ8' },
+      { pwid: 'peerid-9', inx: 8, key: 'jWHSkVVAx5ASBGevjB6Y8WK1WCtvMyK8ThUdynPXtQ8' },
+      { pwid: 'peerid-10', inx: 9, key: 'qKRsC7UkrM82gXZCW4oAeZnJJj7ASFJQkgrK8ppGzxc' },
       { pwid: 'peerid-11', inx: 10, key: 'khQkCDzMCLCbt_h5trtLLpLUJry0sh25KeChnlM01po' },
       { pwid: 'peerid-12', inx: 11, key: 'PtGYq1ZcS9LQrqZXAihv6SfCTyxbCKZOq4geiR38JOA' },
       { pwid: 'peerid-13', inx: 12, key: 'xkSbImLPz0ptEBHE7hZNOyZrSmO2sCgWq7ZtL8Jkvc8' },
@@ -130,6 +113,141 @@ describe('DidKey Pairwise keys', () => {
       { pwid: 'peerid-99', inx: 99, key: 'OkGQJ3DbhhbP_TAK0nQVuUE09VEROtP_pfBZvvvbzdE' }
     ];
 
+    it('Check PairwiseId generation uniqueness', () => {
+      let inx: number = 0;
+      let results: string[] = [];
+      const alg = { name: 'ECDSA', namedCurve: 'P-256K', hash: { name: 'SHA-256' } };
+      let didKey: DidKey = new DidKey(crypto, alg, KeyType.EC, KeyUse.Signature, null);
+      for (inx = 0 ; inx < 1000; inx++) {
+        didKey.generatePairwise(seed, `did=${inx}`, 'peer').then((pairwiseKey: DidKey) => {
+          pairwiseKey.jwkKey.then((jwk) => {
+            results.push(jwk.d);
+            // console.log(`Check ${jwk.d} ${results.length}`);
+            expect(1).toBe(results.filter(element => element === jwk.d).length);
+          })
+          .catch((err) => {
+            fail(`Error occured: '${err}'`);
+          });
+        })
+        .catch((err) => {
+          fail(`Error occured: '${err}'`);
+        });
+      }
+    });
+
+    it('Check PairwiseId generation uniqueness with different seed', (done) => {
+      let inx: number = 0;
+      let nrIds: number = 100;
+      let ids: string[] = [];
+      for (inx = 0; inx < nrIds; inx++) {
+        ids.push(`peerid-${inx}`);
+      }
+
+      let did: string = 'abcdef';
+      let seed = Buffer.from('yprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi');
+      const alg = { name: 'ECDSA', namedCurve: 'P-256K', hash: { name: 'SHA-256' } };
+      let didKey: DidKey = new DidKey(crypto, alg, KeyType.EC, KeyUse.Signature, null);
+      inx = 0;
+      for (let pwid of ids) {
+        didKey.generatePairwise(seed, did, pwid).then((pairwiseKey: DidKey) => {
+          pairwiseKey.jwkKey.then((jwk) => {
+            // console.log(`{ pwid: '${pwid}', inx: ${inx++}, key: '${jwk.d}'},`);
+            pairwiseKeys.forEach((element: any) => {
+              if (element.pwid === pwid) {
+                // console.log(`Check ${element.inx}: ${element.key} == ${jwk.d}`);
+                expect(element.key).not.toBe(jwk.d);
+                expect(0).toBe(pairwiseKeys.filter(element => element === jwk.d).length);
+                return;
+              }
+            });
+          })
+          .catch((err) => {
+            fail(`Error occured: '${err}'`);
+          });
+        })
+        .catch((err) => {
+          fail(`Error occured: '${err}'`);
+        });
+      }
+
+      done();
+    });
+
+    it('Check PairwiseId generation uniqueness with different peer', (done) => {
+      let inx: number = 0;
+      let nrIds: number = 100;
+      let ids: string[] = [];
+      for (inx = 0; inx < nrIds; inx++) {
+        ids.push(`peerid--${inx}`);
+      }
+
+      let did: string = 'abcdef';
+      const alg = { name: 'ECDSA', namedCurve: 'P-256K', hash: { name: 'SHA-256' } };
+      let didKey: DidKey = new DidKey(crypto, alg, KeyType.EC, KeyUse.Signature, null);
+      inx = 0;
+      for (let pwid of ids) {
+        didKey.generatePairwise(seed, did, pwid).then((pairwiseKey: DidKey) => {
+          pairwiseKey.jwkKey.then((jwk) => {
+            // console.log(`{ pwid: '${pwid}', inx: ${inx++}, key: '${jwk.d}'},`);
+            pairwiseKeys.forEach((element: any) => {
+              if (element.pwid === pwid) {
+                // console.log(`Check ${element.inx}: ${element.key} == ${jwk.d}`);
+                expect(element.key).not.toBe(jwk.d);
+                expect(0).toBe(pairwiseKeys.filter(element => element === jwk.d).length);
+                return;
+              }
+            });
+          })
+          .catch((err) => {
+            fail(`Error occured: '${err}'`);
+          });
+        })
+        .catch((err) => {
+          fail(`Error occured: '${err}'`);
+        });
+      }
+
+      done();
+    });
+
+    it('Check PairwiseId generation uniqueness with different did', (done) => {
+      let inx: number = 0;
+      let nrIds: number = 100;
+      let ids: string[] = [];
+      for (inx = 0; inx < nrIds; inx++) {
+        ids.push(`peerid-${inx}`);
+      }
+
+      let did: string = 'abcdef';
+      let seed = Buffer.from('yprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi');
+      const alg = { name: 'ECDSA', namedCurve: 'P-256K', hash: { name: 'SHA-256' } };
+      inx = 0;
+      let didKey: DidKey = new DidKey(crypto, alg, KeyType.EC, KeyUse.Signature, null);
+      for (let pwid of ids) {
+        didKey.generatePairwise(seed, did, pwid).then((pairwiseKey: DidKey) => {
+          pairwiseKey.jwkKey.then((jwk) => {
+            // console.log(`{ pwid: '${pwid}', inx: ${inx++}, key: '${jwk.d}'},`);
+            pairwiseKeys.forEach((element: any) => {
+              if (element.pwid === pwid) {
+                // console.log(`Check ${element.inx}: ${element.key} == ${jwk.d}`);
+                expect(element.key).not.toBe(jwk.d);
+                expect(0).toBe(pairwiseKeys.filter(element => element === jwk.d).length);
+                return;
+              }
+            });
+          })
+          .catch((err) => {
+            fail(`Error occured: '${err}'`);
+          });
+        })
+        .catch((err) => {
+          fail(`Error occured: '${err}'`);
+        });
+      }
+
+      done();
+    });
+
     it('Check PairwiseId generation', (done) => {
       let inx: number = 0;
       let nrIds: number = 100;
@@ -139,7 +257,7 @@ describe('DidKey Pairwise keys', () => {
       }
 
       let did: string = 'abcdef';
-      const alg = { name: 'ECDSA', namedCurve: 'K-256', hash: { name: 'SHA-256' } };
+      const alg = { name: 'ECDSA', namedCurve: 'P-256K', hash: { name: 'SHA-256' } };
       let didKey: DidKey = new DidKey(crypto, alg, KeyType.EC, KeyUse.Signature, null);
       inx = 0;
       for (let pwid of ids) {
@@ -153,7 +271,13 @@ describe('DidKey Pairwise keys', () => {
                 return;
               }
             });
+          })
+          .catch((err) => {
+            fail(`Error occured: '${err}'`);
           });
+        })
+        .catch((err) => {
+          fail(`Error occured: '${err}'`);
         });
       }
 

--- a/tests/crypto/DidKeyPairwise.spec.ts
+++ b/tests/crypto/DidKeyPairwise.spec.ts
@@ -1,0 +1,164 @@
+import DidKey from '../../lib/crypto/DidKey';
+import { KeyType } from '../../lib/crypto/KeyType';
+import { KeyUse } from '../../lib/crypto/KeyUse';
+import WebCrypto from 'node-webcrypto-ossl';
+
+const crypto = new WebCrypto();
+
+describe('DidKey Pairwise keys', () => {
+
+  describe('Test Pairwise key generation', () => {
+
+    it('Check PairwiseId generation uniqueness', () => {
+      let inx: number = 0;
+      let results: string[] = [];
+      const alg = { name: 'ECDSA', namedCurve: 'K-256', hash: { name: 'SHA-256' } };
+      let didKey: DidKey = new DidKey(crypto, alg, KeyType.EC, KeyUse.Signature, null);
+      for (inx = 0 ; inx < 1000; inx++) {
+        didKey.generatePairwise(seed, `did=${inx}`, 'peer').then((pairwiseKey: DidKey) => {
+          pairwiseKey.jwkKey.then((jwk) => {
+            results.push(jwk.d);
+            console.log(`Check ${jwk.d} ${results.length}`);
+            expect(1).toBe(results.filter(element => element === jwk.d).length);
+          });
+        });
+      }
+    });
+
+    let seed = Buffer.from('xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi');
+
+    let pairwiseKeys: {pwid: string, inx: number, key: string}[] = [
+      { pwid: 'peerid-0', inx: 0, key: 'pWKivj0j2FGXbKO-ET7EY0jeUgtUv7ERleZ-BxJta_Q' },
+      { pwid: 'peerid-1', inx: 1, key: 'Cs5abc9y89BPQMv3UjsEVRu9ejc5yMlaDjnY26LGQFY' },
+      { pwid: 'peerid-2', inx: 2, key: '3NkPrg5hjI8nLo44dMS8rAVI3CG1h_g_DNwGYdUxfp4' },
+      { pwid: 'peerid-4', inx: 3, key: 'M7WGYc1P2ICW890HEFn7LuR58zR4BQD5n9pXjBOETCc' },
+      { pwid: 'peerid-5', inx: 4, key: 'kYfrLuyRQhvXYo2Ym8pFVO7pe8kdxhTIGR4y6cTLaew' },
+      { pwid: 'peerid-6', inx: 5, key: 'PMhhBrw9LAsYS34DCDFnxeG5eI0noOW8dJbhNW8jZR4' },
+      { pwid: 'peerid-7', inx: 6, key: 'aoKDyrnQEwWLTvUlEgnvsaVm-yW8LfvaFRP51Rpo1d8' },
+      { pwid: 'peerid-8', inx: 7, key: 'sPGK4xCGBmhjTGVSxzgTNTEr54gHtbTzWRhAHE0YQGY' },
+      { pwid: 'peerid-10', inx: 8, key: 'qKRsC7UkrM82gXZCW4oAeZnJJj7ASFJQkgrK8ppGzxc' },
+      { pwid: 'peerid-9', inx: 9, key: 'jWHSkVVAx5ASBGevjB6Y8WK1WCtvMyK8ThUdynPXtQ8' },
+      { pwid: 'peerid-11', inx: 10, key: 'khQkCDzMCLCbt_h5trtLLpLUJry0sh25KeChnlM01po' },
+      { pwid: 'peerid-12', inx: 11, key: 'PtGYq1ZcS9LQrqZXAihv6SfCTyxbCKZOq4geiR38JOA' },
+      { pwid: 'peerid-13', inx: 12, key: 'xkSbImLPz0ptEBHE7hZNOyZrSmO2sCgWq7ZtL8Jkvc8' },
+      { pwid: 'peerid-14', inx: 13, key: 'ql0rreYY_F27K-bR4pWqQvczEO1yp75WfIlwra5SeLQ' },
+      { pwid: 'peerid-15', inx: 14, key: '2tkVT4rB3MFHktAzIEjvNSlGM0_OZ7KQYNjUR3_IyX0' },
+      { pwid: 'peerid-16', inx: 15, key: 'SgBbsLGn3luKPFDrUAejsr0nfMTdt-LsXv0zZ_9Xs4E' },
+      { pwid: 'peerid-17', inx: 16, key: 'nX7mvv_Kn3qjQdvZSSf5agy_IVG3y1Z-zwy9EHjRNww' },
+      { pwid: 'peerid-18', inx: 17, key: '3F-oe4-0wVh_7lADAL0UZvBUMkseGAQBGD-4ehuvBvo' },
+      { pwid: 'peerid-20', inx: 18, key: 'rblKHssJu9Z0voQs1UK3XN46leQZ8dd1jWWNqSPtJCw' },
+      { pwid: 'peerid-3', inx: 19, key: 'LlyQFlcgAyGMGzkv8_Vs4uMY1sG2Kwqz1vn1AHlqIl4' },
+      { pwid: 'peerid-21', inx: 20, key: 'VwgrEYsMB3xJs9CFZHPEBiFc8L6xlmh40iMO5KIx6Bo' },
+      { pwid: 'peerid-23', inx: 21, key: 'K0G93E2Nqbo5-glvBZJ_IBPHMR8-UxyyvbJaz_tsOFE' },
+      { pwid: 'peerid-22', inx: 22, key: 'heXfLXiDJFrmeQq4YPygqOkvV75jjdDOsbgDaH81gg4' },
+      { pwid: 'peerid-24', inx: 23, key: 'fXSSfbgM1Z78EqRQpj0xz-XSoCK46oH4iMd1JW-kaYc' },
+      { pwid: 'peerid-25', inx: 24, key: 'YRBhc0_L31c9SwNJRJ2hCPfjq9LRGxQpIo_D7xaNzTk' },
+      { pwid: 'peerid-26', inx: 25, key: 'FYUjaEuEnuaJGnRce5wY8zAgEILwu-5CDzvE4VjZKIE' },
+      { pwid: 'peerid-27', inx: 26, key: '6nGJUihawRsILu3RcsPZq6RCkckxzjtoJQwwauPUbA0' },
+      { pwid: 'peerid-28', inx: 27, key: 'kzX_1eYBWNqBpq6-W_HAq-z5LOeY3aBq80bxHl-zXYw' },
+      { pwid: 'peerid-29', inx: 28, key: 'B3oJMjEW6W37K9HXLAAfQcWnKEH-Np7jWMmWv6wv804' },
+      { pwid: 'peerid-30', inx: 29, key: 's-iYtgb4-VwE7yHLqDFFyuA0s94EARJvBpqUjGg8Izk' },
+      { pwid: 'peerid-31', inx: 30, key: 'RNElPT7X26XeR2VG_Llih7VVm6nrGtnVC-li3hEqcfE' },
+      { pwid: 'peerid-32', inx: 31, key: 'Cs_SpJP98qNOLJLn-BfTcM4wQ0WmBjbXuilbPTCqkb4' },
+      { pwid: 'peerid-33', inx: 32, key: 'WitaRk-I_7GTEMHuUi4aVxFxBApBOhm9Rn5E-GETYlY' },
+      { pwid: 'peerid-34', inx: 33, key: 'OFPWhFiPNcNK8cFTZo61a7eTEbU645H7n0nWTmUQbP4' },
+      { pwid: 'peerid-35', inx: 34, key: 'rSFVZa3trSB_WwYGMFaa_QFKyigG4kiCOrrUO4t5Mm4' },
+      { pwid: 'peerid-36', inx: 35, key: 'i9u7aEo_SvNwnno_4CkHkFgxov7A52zPji9GsyhvRJs' },
+      { pwid: 'peerid-37', inx: 36, key: 'egTaXivftc1T8ShF939xCILuQl6hFAgFOVqMozg2tPc' },
+      { pwid: 'peerid-38', inx: 37, key: '-w5Az5QMUscW1F1U42RJh4HRyNdXGe8nTE8euXweELc' },
+      { pwid: 'peerid-39', inx: 38, key: '0kNl4_S-BWr4n2XZoD5g88orljzwVrFBMwCJFJicp4Q' },
+      { pwid: 'peerid-40', inx: 39, key: 'gspD7BhNILp48yNpu1EPLjtcRS96_XBVJTUKNkuOAK8' },
+      { pwid: 'peerid-41', inx: 40, key: '-meLcZBcSS0bCGo-Y9jI6ThQiQWmqfRij6Wp5clyOgY' },
+      { pwid: 'peerid-43', inx: 41, key: 'df7_EgNXI957v3sjLHNunwHpzy0Mlvpe9DkuMjh1Ids' },
+      { pwid: 'peerid-44', inx: 42, key: 'ZH4s0fE3FNYAj6sKl1Hanrb3rrJSh1j8a_zut5_oKDM' },
+      { pwid: 'peerid-45', inx: 43, key: 'nU_77EA7wHTvrmAk1Snsp3bKPgGE_Fet8wNAZ-cPcf8' },
+      { pwid: 'peerid-46', inx: 44, key: 'n8D7H9nv579AGqYAP0lDapq2A6ZBWGYhrcl1EDHKLT4' },
+      { pwid: 'peerid-47', inx: 45, key: 'Is4Y4D4QAMPjzERyTbVwFvUADPaC0KT2Z_I7grvztSA' },
+      { pwid: 'peerid-48', inx: 46, key: 'f0PhmST4IiWbshcO5i-JkqV3yEprY3jsm-de80CbPFo' },
+      { pwid: 'peerid-49', inx: 47, key: 'zSALe1w6v61qBjBMHuXRGUKqHDISWscGw7Y01GIwULU' },
+      { pwid: 'peerid-50', inx: 48, key: '4OBtZzn4WRspzNVy_XtuhEYsdgj8BIDfXrZJbXjvKQ8' },
+      { pwid: 'peerid-42', inx: 49, key: 'NG6NDqdk3p3zCeozuKOJVi8IeQBU21DNB8du1Uf1KrM' },
+      { pwid: 'peerid-51', inx: 50, key: 'qe_mS3hr-evA6oMcIivNdGGh3oEZMNfJsox-a6BMuAo' },
+      { pwid: 'peerid-52', inx: 51, key: 'R07x-CNTj0rE6LUzQJhx4bcBX4sKF_JEDV0wsuP50v0' },
+      { pwid: 'peerid-53', inx: 52, key: '1X5orlEfpsV6RximCbXLkrhg6rH3A-ubNeilkjs4Bmk' },
+      { pwid: 'peerid-54', inx: 53, key: 'mH9X4A8ttzeOVxUZvSJlFt1xCodS9lXXsTHoF9-Y0HU' },
+      { pwid: 'peerid-55', inx: 54, key: 'rrsGFSt0g2Auuldbno6WyPEKR26XhOxBLBPndSIP-T4' },
+      { pwid: 'peerid-56', inx: 55, key: '1Qde7EqTZNp4k1BKHzx70bhlDYos6kLD1apjYU4pwaQ' },
+      { pwid: 'peerid-58', inx: 56, key: '4o6gLtvCLI2LQTUaMg4OiRPxzpLFkjNhNU8h4jcoDNQ' },
+      { pwid: 'peerid-57', inx: 57, key: 'fNQ_RIV-nj8oVtfKpsSIFoEj34Nn09e3Y9j1QE9Y1ts' },
+      { pwid: 'peerid-60', inx: 58, key: 'CkzsW7sFpXhGyRjTbskEyORBeSc92Li62KnNlEY0bAM' },
+      { pwid: 'peerid-59', inx: 59, key: '3PT4TgzmOWz53dSwu_RghvYgpWAxSGVtbascTknjkuU' },
+      { pwid: 'peerid-61', inx: 60, key: 'htXUlvUJpqS0zXIgpWfgu2I0f75CqE9tceG6nZLSKXQ' },
+      { pwid: 'peerid-19', inx: 61, key: 'LxC5NabUlx9taHePLJz4spHxiwvx_dxts2jdlihMe2E' },
+      { pwid: 'peerid-62', inx: 62, key: 'fV0JpjPQH5SG358B2mPaGo7V8Iw7NEaufx1yCEQVP5o' },
+      { pwid: 'peerid-63', inx: 63, key: 'qhW3wwtra4DSxGauRScsz-aipMGEvO6njE31_Z_lF5Y' },
+      { pwid: 'peerid-64', inx: 64, key: '9eJOBHmaqwgEsFRxJiYbaZ13IixKN9HzWp4IwfTU0OI' },
+      { pwid: 'peerid-65', inx: 65, key: 'uLCYmWWF8WFIbDdaMNwIYBvW_4vmBeG0kXF3917uwR0' },
+      { pwid: 'peerid-66', inx: 66, key: 'ZZmnUoXl7Vlbv0aqgWUmOubL5UH-s7YVsKaQwlTkLK0' },
+      { pwid: 'peerid-67', inx: 67, key: 'G5hK63UI1G4xfHgDPtpoXBlxtP66EOuDFJLbPNwkn34' },
+      { pwid: 'peerid-68', inx: 68, key: 'y_Pj-5jWQpgyiM7NMpwuo6Mcs5L4502tt1cd0tLJqYY' },
+      { pwid: 'peerid-69', inx: 69, key: '40lu1zYZd0M7YTW31So62JwHzVv2kZPMCAxSI97cHGQ' },
+      { pwid: 'peerid-70', inx: 70, key: 'm40SjcOA391ViLet4M8cB3ax6-a_LvwwMavowZZvxnI' },
+      { pwid: 'peerid-71', inx: 71, key: 'QmQkMgMVjhviFBXQrN99SqIoteXZLGF_XBCuglRqP3s' },
+      { pwid: 'peerid-72', inx: 72, key: '6ytaR-cYNQj3tpILWcuPKR-Nqw4JkzdjjSKu2IkG50Y' },
+      { pwid: 'peerid-73', inx: 73, key: '--fe_aBszkQ4A-hCcIjA7dbdxP3OeJYtYE4GR9g_TD4' },
+      { pwid: 'peerid-74', inx: 74, key: 'MenCC5jys_AovvIXioX8NkWpGTvNJIrz7MFvJ5mWBh8' },
+      { pwid: 'peerid-75', inx: 75, key: 'T8K4l_P6Z1ckJLL2Nm0-5rTTqbLriF3fTy-U-ldd-_Y' },
+      { pwid: 'peerid-76', inx: 76, key: 'z0Q38au95DhQHjQKoW0uj26R0s9yBQ_MGOdz28mFefQ' },
+      { pwid: 'peerid-77', inx: 77, key: 'ZJSvz1RTvFQkrXkTspSUw8hfxELqnhlNfDdWqDmT9qE' },
+      { pwid: 'peerid-79', inx: 78, key: '4HAETI1Llf1n8_BLTyJQEPTZXIAsGnLRRvsa43AXYNg' },
+      { pwid: 'peerid-78', inx: 79, key: '-P3tqJXUxO9IjYxnz4nCZQRNykL1iWGyy0RdYvFdU_U' },
+      { pwid: 'peerid-80', inx: 80, key: 'Ykf5KboBShsEri98VWxd96XwH2UgeAzf1y0p1B9tC44' },
+      { pwid: 'peerid-81', inx: 81, key: 'aqmm0OGXTWKF5arkx_if0eQE8EoJwIQveZRFiEL7SAs' },
+      { pwid: 'peerid-82', inx: 82, key: 'Z_7gdgHzA2y5_lnzufcBbaePmsAqblZ1DAd4YFVbDag' },
+      { pwid: 'peerid-83', inx: 83, key: 'XCUzt38BmVJ9Z1oigvuaLDi5MSycFfh0TFxhjybdYHk' },
+      { pwid: 'peerid-84', inx: 84, key: 'R-IGTcIVrEsAd0fZ_YLm2k9crP-7gBRTK1I6B6JnOrs' },
+      { pwid: 'peerid-85', inx: 85, key: 'UMp71hA4njywZs1gpS3VHzRHQ1j05bPUXhmTPQjee_Q' },
+      { pwid: 'peerid-86', inx: 86, key: 'ixjKHkzsoeM68Ufs1GYr8xMY0OcsNUM2709jhZmnkjU' },
+      { pwid: 'peerid-87', inx: 87, key: 'xUIRePCK88TLP7PWNUo4KY5jn70mcIBCf01odD6PyII' },
+      { pwid: 'peerid-88', inx: 88, key: '8ubmrohbXhoeCbapCj2gwM7tb-LDfCjBKaLqc6bhPqE' },
+      { pwid: 'peerid-90', inx: 89, key: 'MNYaZ6CLwltycNK3uJ20HtjpHqCGbJ340rAZ0RXt65E' },
+      { pwid: 'peerid-91', inx: 90, key: 'I5a_V2GOOrTNQKIlf3Y7gXjy603RCohADM3ftiNn5XM' },
+      { pwid: 'peerid-89', inx: 91, key: 'AQLO8nXqFbz_ifnXs-DRnSNuEGeXCeowWp-iG3xy2Dc' },
+      { pwid: 'peerid-92', inx: 92, key: 'uueNyb1IiNIGjttAEnDilhqCn9xNQz765zxYNwLkSSs' },
+      { pwid: 'peerid-95', inx: 93, key: '7sOY9BSoSsGa_sNlei_2GalKg4Zvkyvz8AqplNXhp7g' },
+      { pwid: 'peerid-93', inx: 94, key: '4ea9gDLzA3HhPFBHewGxWJCFcw1083ZXSYj1M_zth74' },
+      { pwid: 'peerid-96', inx: 95, key: 'Lqnm9Qba2A4WjHWnpwjwRp5RGRpFEHprJ-XYXoq7D30' },
+      { pwid: 'peerid-94', inx: 96, key: 'djaYx-6YjW9l2dLr1ko-dQPbLh7bCMWjLJ_Wj8Nnvyo' },
+      { pwid: 'peerid-97', inx: 97, key: 'UPHOzPEzug5i0KWDBVDVguzQkfIG9GmeuvWFZt7i4rA' },
+      { pwid: 'peerid-98', inx: 98, key: 'Zh84KpZ_cUD4d309NABzrSDzjOEDB5_nsytfFjbAuak' },
+      { pwid: 'peerid-99', inx: 99, key: 'OkGQJ3DbhhbP_TAK0nQVuUE09VEROtP_pfBZvvvbzdE' }
+    ];
+
+    it('Check PairwiseId generation', (done) => {
+      let inx: number = 0;
+      let nrIds: number = 100;
+      let ids: string[] = [];
+      for (inx = 0; inx < nrIds; inx++) {
+        ids.push(`peerid-${inx}`);
+      }
+
+      let did: string = 'abcdef';
+      const alg = { name: 'ECDSA', namedCurve: 'K-256', hash: { name: 'SHA-256' } };
+      let didKey: DidKey = new DidKey(crypto, alg, KeyType.EC, KeyUse.Signature, null);
+      inx = 0;
+      for (let pwid of ids) {
+        didKey.generatePairwise(seed, did, pwid).then((pairwiseKey: DidKey) => {
+          pairwiseKey.jwkKey.then((jwk) => {
+            // console.log(`{ pwid: '${pwid}', inx: ${inx++}, key: '${jwk.d}'},`);
+            pairwiseKeys.forEach((element: any) => {
+              if (element.pwid === pwid) {
+                // console.log(`Check ${element.inx}: ${element.key} == ${jwk.d}`);
+                expect(element.key).toBe(jwk.d);
+                return;
+              }
+            });
+          });
+        });
+      }
+
+      done();
+    });
+
+  });
+});

--- a/tests/crypto/KeyObject.spec.ts
+++ b/tests/crypto/KeyObject.spec.ts
@@ -5,7 +5,17 @@ import WebCrypto from 'node-webcrypto-ossl';
 const crypto = new WebCrypto();
 
 describe('Constructor', () => {
-  describe('Test constructor oct key', () => {
+  describe('Test constructor', () => {
+    it('Throw exception.', () => {
+      try {
+        let key = new KeyObject(KeyType.RSA, {});
+        expect(key).toBeUndefined();
+      } catch (err) {
+        expect(err).toEqual(jasmine.any(Error));
+        expect(`Key with type 'RSA' is expected to have the type public or private`).toBe(err.message);
+      }
+    });
+
     it('Should set the right properties for the symmetric key.', (done) => {
       const alg = { name: 'hmac', hash: 'SHA-256' };
       crypto.subtle.generateKey(alg, true, [ 'sign' ]).then((key) => {

--- a/tests/crypto/KeyObject.spec.ts
+++ b/tests/crypto/KeyObject.spec.ts
@@ -1,0 +1,62 @@
+import KeyObject from '../../lib/crypto/KeyObject';
+import { KeyType } from '../../lib/crypto/KeyType';
+import WebCrypto from 'node-webcrypto-ossl';
+
+const crypto = new WebCrypto();
+
+describe('Constructor', () => {
+  describe('Test constructor oct key', () => {
+    it('Should set the right properties for the symmetric key.', (done) => {
+      const alg = { name: 'hmac', hash: 'SHA-256' };
+      crypto.subtle.generateKey(alg, true, [ 'sign' ]).then((key) => {
+        let keyObject: KeyObject = new KeyObject(KeyType.Oct, key);
+        expect(KeyType.Oct).toBe(keyObject.keyType);
+        expect(false).toBe(keyObject.isKeyPair);
+        expect(false).toBe(keyObject.isPublicKeyCrypto);
+        done();
+      });
+    });
+
+    it('Should set the right properties for the EC key.', (done) => {
+      let alg: any = { name: 'ECDH', namedCurve: 'K-256' };
+      crypto.subtle.generateKey(alg, true, [ 'deriveBits' ]).then((key) => {
+        let keyObject: KeyObject = new KeyObject(KeyType.EC, key);
+        expect(KeyType.EC).toBe(keyObject.keyType);
+        expect(true).toBe(keyObject.isKeyPair);
+        expect(true).toBe(keyObject.isPublicKeyCrypto);
+        done();
+      });
+    });
+
+    it('Should set the right properties for the imported private key.', (done) => {
+      let alg: any = { name: 'ECDH', namedCurve: 'K-256' };
+      crypto.subtle.generateKey(alg, true, [ 'deriveBits' ]).then((key: any) => {
+        crypto.subtle.exportKey('jwk', key.privateKey).then((jwkKey: any) => {
+          crypto.subtle.importKey('jwk', jwkKey, alg, true, [ 'deriveBits' ]).then((key: any) => {
+            let keyObject: KeyObject = new KeyObject(KeyType.EC, key);
+            expect(KeyType.EC).toBe(keyObject.keyType);
+            expect(false).toBe(keyObject.isKeyPair);
+            expect(true).toBe(keyObject.isPublicKeyCrypto);
+            done();
+          });
+        });
+      });
+    });
+
+    it('Should set the right properties for the imported public key.', (done) => {
+      let alg: any = { name: 'ECDH', namedCurve: 'K-256' };
+      crypto.subtle.generateKey(alg, true, [ 'deriveBits' ]).then((key: any) => {
+        crypto.subtle.exportKey('jwk', key.publicKey).then((jwkKey: any) => {
+          crypto.subtle.importKey('jwk', jwkKey, alg, true, [ 'deriveBits' ]).then((key: any) => {
+            let keyObject: KeyObject = new KeyObject(KeyType.EC, key);
+            expect(KeyType.EC).toBe(keyObject.keyType);
+            expect(false).toBe(keyObject.isKeyPair);
+            expect(true).toBe(keyObject.isPublicKeyCrypto);
+            done();
+          });
+        });
+      });
+    });
+
+  });
+});

--- a/tests/crypto/PairwiseKey.spec.ts
+++ b/tests/crypto/PairwiseKey.spec.ts
@@ -1,0 +1,57 @@
+import PairwiseKey from '../../lib/crypto/PairwiseKey';
+import DidKey from '../../lib/crypto/DidKey';
+import { KeyType } from '../../lib/crypto/KeyType';
+import { KeyUse } from '../../lib/crypto/KeyUse';
+import WebCrypto from 'node-webcrypto-ossl';
+
+const crypto = new WebCrypto();
+
+describe('PairwiseKey', () => {
+  describe('Test constructor', () => {
+    it('Should set the right properties.', () => {
+      let key = new PairwiseKey('1234567890', 'www.peer.com');
+      expect('1234567890-www.peer.com').toBe(key.id);
+      expect(key.key).toBeNull();
+    });
+
+  });
+
+  describe('generate', () => {
+    it('Throw exception.', () => {
+      let masterKey: Buffer = Buffer.alloc(32, 2);
+      const alg = { name: 'ECDSA', namedCurve: 'K-256', hash: { name: 'SHA-256' } };
+      let key = new PairwiseKey('1234567890', 'www.peer.com');
+      try {
+        key.generate(masterKey, crypto, alg, KeyType.Oct, KeyUse.Signature);
+      } catch (err) {
+        expect(err).toEqual(jasmine.any(Error));
+        expect('Pairwise key for key type oct is not supported').toBe(err.message);
+      }
+    });
+
+    it('Generate key pair.', (done) => {
+      let masterKey: Buffer = Buffer.alloc(32, 1);
+      let key = new PairwiseKey('1234567890', 'www.peer.com');
+      const alg = { name: 'ECDSA', namedCurve: 'K-256', hash: { name: 'SHA-256' } };
+      key.generate(masterKey, crypto, alg, KeyType.EC, KeyUse.Signature, true).then((didKey: DidKey) => {
+        expect(didKey).toBeDefined();
+        didKey.jwkKey.then((jwk) => {
+          const data = 'abcdefghij';
+          didKey.sign(Buffer.from(data)).then((signature: ArrayBuffer) => {
+            // Make sure there is only the public key
+            jwk.d = undefined;
+            didKey = new DidKey(crypto, alg, KeyType.EC, KeyUse.Signature, jwk, true);
+            didKey.jwkKey.then(() => {
+              didKey.verify(Buffer.from(data), signature).then((correct: boolean) => {
+                expect(true).toBe(correct);
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+  });
+
+});

--- a/tests/crypto/PairwiseKey.spec.ts
+++ b/tests/crypto/PairwiseKey.spec.ts
@@ -22,7 +22,10 @@ describe('PairwiseKey', () => {
       const alg = { name: 'ECDSA', namedCurve: 'K-256', hash: { name: 'SHA-256' } };
       let key = new PairwiseKey('1234567890', 'www.peer.com');
       try {
-        key.generate(masterKey, crypto, alg, KeyType.Oct, KeyUse.Signature);
+        key.generate(masterKey, crypto, alg, KeyType.Oct, KeyUse.Signature)
+        .catch(() => {
+          fail('The catch should not happen because exception occurs before promise is generated');
+        });
       } catch (err) {
         expect(err).toEqual(jasmine.any(Error));
         expect('Pairwise key for key type oct is not supported').toBe(err.message);
@@ -45,10 +48,25 @@ describe('PairwiseKey', () => {
               didKey.verify(Buffer.from(data), signature).then((correct: boolean) => {
                 expect(true).toBe(correct);
                 done();
+              })
+              .catch((err) => {
+                fail(`Error occured: '${err}'`);
               });
+            })
+            .catch((err) => {
+              fail(`Error occured: '${err}'`);
             });
+          })
+          .catch((err) => {
+            fail(`Error occured: '${err}'`);
           });
+        })
+        .catch((err) => {
+          fail(`Error occured: '${err}'`);
         });
+      })
+      .catch((err) => {
+        fail(`Error occured: '${err}'`);
       });
     });
 

--- a/tests/crypto/PairwiseKey.spec.ts
+++ b/tests/crypto/PairwiseKey.spec.ts
@@ -11,7 +11,7 @@ describe('PairwiseKey', () => {
     it('Should set the right properties.', () => {
       let key = new PairwiseKey('1234567890', 'www.peer.com');
       expect('1234567890-www.peer.com').toBe(key.id);
-      expect(key.key).toBeNull();
+      expect(key.key).toBeUndefined();
     });
 
   });


### PR DESCRIPTION
Added new crypto layer to implement pairwise keys. An EC key pair can be generated unique for the peer you are communicating with.
The scheme is a deterministic scheme which will produce the same keys on different user agents.