### PR TITLE
Beejones/return normalized crv for jwks

### DIFF
--- a/lib/crypto/DidKey.ts
+++ b/lib/crypto/DidKey.ts
@@ -131,7 +131,7 @@ export default class DidKey {
         jwkPublic.e = jwk.e;
         jwkPublic.n = jwk.n;
       } else {
-        jwkPublic.crv = jwk.crv;
+        jwkPublic.crv = this._algorithm.namedCurve;
         jwkPublic.x = jwk.x;
         jwkPublic.y = jwk.y;
       }
@@ -373,7 +373,11 @@ export default class DidKey {
         break;
     }
 
-    return this._crypto.subtle.exportKey('jwk', nativeKey);
+    let jwk = await this._crypto.subtle.exportKey('jwk', nativeKey);
+    if (jwk.kty === 'EC') {
+      jwk.crv = this._algorithm.namedCurve;
+    }
+    return jwk;
   }
 
   private getKeyIdentifier (keyType: KeyType, keyUse: KeyUse, keyExport: KeyExport): string {

--- a/lib/crypto/DidKey.ts
+++ b/lib/crypto/DidKey.ts
@@ -125,6 +125,10 @@ export default class DidKey {
       // Save only public key
       const jwkPublic: any = {};
       jwkPublic.kty = jwk.kty;
+      if (!jwk.kid) {
+        jwk.kid = jwkPublic.kid = '#key1';
+      }
+
       jwkPublic.use = jwk.use;
       jwkPublic.key_ops = jwk.key_ops;
       if (this.keyType === KeyType.RSA) {
@@ -358,7 +362,11 @@ export default class DidKey {
 
   // Transform the oct KeyObject into a JWK key.
   private async getOctJwkKey (keyObject: KeyObject): Promise<any> {
-    return this._crypto.subtle.exportKey('jwk', keyObject.secretKey);
+    const jwk = await this._crypto.subtle.exportKey('jwk', keyObject.secretKey);
+    if (!jwk.kid) {
+      jwk.kid = '#kid1';
+    }
+    return jwk;
   }
 
   // Transform the key pair KeyObject into a JWK key.
@@ -431,10 +439,14 @@ export default class DidKey {
     if (!key.kty) {
       jwkKey = {
         kty: 'oct',
+        kid: '#key1',
         use: this.keyUse,
         k: base64url(key)
       };
     } else {
+      if (!key.kid) {
+        key.kid = '#key1';
+      }
       jwkKey = key;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4072,7 +4072,7 @@
         },
         "async": {
           "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "resolved": false,
           "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
           "dev": true,
           "requires": {
@@ -4319,7 +4319,7 @@
         },
         "handlebars": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
+          "resolved": false,
           "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
           "dev": true,
           "requires": {
@@ -4470,7 +4470,7 @@
         },
         "istanbul-reports": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
           "dev": true,
           "requires": {
@@ -4556,7 +4556,7 @@
         },
         "mem": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
+          "resolved": false,
           "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
           "dev": true,
           "requires": {
@@ -4634,7 +4634,7 @@
         },
         "normalize-package-data": {
           "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "resolved": false,
           "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
           "dev": true,
           "requires": {
@@ -4709,7 +4709,7 @@
         },
         "p-is-promise": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
           "dev": true
         },
@@ -4779,7 +4779,7 @@
         },
         "path-parse": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "resolved": false,
           "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
           "dev": true
         },
@@ -4867,7 +4867,7 @@
         },
         "resolve": {
           "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+          "resolved": false,
           "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
           "dev": true,
           "requires": {
@@ -5563,7 +5563,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },

--- a/tests/crypto/DidKey.Pairwise.EC.spec.ts
+++ b/tests/crypto/DidKey.Pairwise.EC.spec.ts
@@ -99,6 +99,7 @@ describe('DidKey - elliptic curve pairwise keys', () => {
       let id = `${inx}`;
       let pairwiseKey: DidKey = await didKey.generatePairwise(seed, did, id);
       let jwk = await pairwiseKey.getJwkKey(KeyExport.Private);
+      expect(jwk.kid).toBeDefined();
 
       console.log(`{ "pwid": "${id}", "key": "${jwk.d}"},`);
       // console.log(`${id}: Check ${pairwiseKeys[inx].pwid}: ${pairwiseKeys[inx].key} == ${jwk.d}`);
@@ -125,6 +126,7 @@ describe('DidKey - elliptic curve pairwise keys', () => {
     for (let pwid of ids) {
       let pairwiseKey: DidKey = await didKey.generatePairwise(seed, did, pwid);
       let jwk = await pairwiseKey.getJwkKey(KeyExport.Private);
+      expect(jwk.kid).toBeDefined();
       // console.log(`{ pwid: '${pwid}', inx: ${inx++}, key: '${jwk.d}'},`);
       pairwiseKeys.forEach((element: any) => {
         if (element.pwid === pwid) {
@@ -154,6 +156,7 @@ describe('DidKey - elliptic curve pairwise keys', () => {
     for (let pwid of ids) {
       let pairwiseKey: DidKey = await didKey.generatePairwise(seed, did, pwid);
       let jwk = await pairwiseKey.getJwkKey(KeyExport.Private);
+      expect(jwk.kid).toBeDefined();
       // console.log(`{ pwid: '${pwid}', inx: ${inx++}, key: '${jwk.d}'},`);
       pairwiseKeys.forEach((element: any) => {
         if (element.pwid === pwid) {

--- a/tests/crypto/DidKey.Pairwise.RSA.spec.ts
+++ b/tests/crypto/DidKey.Pairwise.RSA.spec.ts
@@ -28,6 +28,7 @@ describe('DidKey - RSA pairwise keys', () => {
       const jwk = await pairwiseKey.getJwkKey(KeyExport.Private);
       // The following comments is used to generate a test vector reference file. Do not remove.
       console.log(`{ "pwid": "${id}", "key": "${jwk.d}"},`);
+      expect(jwk.kid).toBeDefined();
 
       expect(pairwiseKeys[index].key).toBe(jwk.d);
       expect(1).toBe(pairwiseKeys.filter((element: any) => element.key === jwk.d).length);

--- a/tests/crypto/DidKey.spec.ts
+++ b/tests/crypto/DidKey.spec.ts
@@ -47,6 +47,7 @@ describe('DidKey', () => {
         let key: any = await didKey.getJwkKey(KeyExport.Secret);
         expect(key).not.toBeNull();
         expect(key.kty).toBe('oct');
+        expect(key.kid).toBeDefined();
         expect(base64url.encode(Buffer.from(sampleKey))).toBe(key.k);
       });
       done();
@@ -64,6 +65,7 @@ describe('DidKey', () => {
         let key = await didKey.getJwkKey(KeyExport.Secret);
         expect(key).not.toBeNull();
         expect(key.kty).toBe('oct');
+        expect(key.kid).toBeDefined();
         expect(key.k).not.toBeNull();
         expect(key.k).not.toBeUndefined();
       });
@@ -244,6 +246,7 @@ describe('DidKey', () => {
 
         const ecKey1 = await didKey.getJwkKey(KeyExport.Private);
         expect(ecKey1).not.toBeNull();
+        expect(ecKey1.kid).toBeDefined();
         expect(ecKey1.crv).toBe('P-256K');
         expect(ecKey1.kty).toBe('EC');
       });

--- a/tests/crypto/DidKey.spec.ts
+++ b/tests/crypto/DidKey.spec.ts
@@ -244,7 +244,7 @@ describe('DidKey', () => {
 
         const ecKey1 = await didKey.getJwkKey(KeyExport.Private);
         expect(ecKey1).not.toBeNull();
-        expect(ecKey1.crv).toBe('K-256');
+        expect(ecKey1.crv).toBe('P-256K');
         expect(ecKey1.kty).toBe('EC');
       });
       done();

--- a/tests/crypto/PairwiseKey.spec.ts
+++ b/tests/crypto/PairwiseKey.spec.ts
@@ -48,6 +48,7 @@ describe('PairwiseKey', () => {
     let didKey: DidKey = await key.generate(masterKey, crypto, alg, KeyType.EC, KeyUse.Signature, true);
     expect(didKey).toBeDefined();
     const jwk = await didKey.getJwkKey(KeyExport.Private);
+    expect(jwk.kid).toBeDefined();
     const data = 'abcdefghij';
     const signature: ArrayBuffer = await didKey.sign(Buffer.from(data));
     // Make sure there is only the public key


### PR DESCRIPTION
Make sure the crv parameter in the jwk is the same as the one passed in the algorithm parameter.
Add dummy kid to jwk. Needs to be replaced by a proper thumbprint.